### PR TITLE
Feature/presseslider

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -111,4 +111,4 @@
     margin: 0;
     letter-spacing: 0.1rem;
   }
-  /*Adding Comment to provoke commit */
+  /*Modifying Comment to provoke commit */

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -111,3 +111,4 @@
     margin: 0;
     letter-spacing: 0.1rem;
   }
+  /*Adding Comment to provoke commit */

--- a/assets/presseslider.css
+++ b/assets/presseslider.css
@@ -1,120 +1,231 @@
-.SectionGrid {
+.ps-SectionGrid {
   display: block;
   grid-template-columns:
     1fr minmax(25px, 200px) minmax(700px, 900px) minmax(25px, 200px)
     1fr;
 }
 
-.SectionGrid-Narrow {
+.ps-SectionGrid-Narrow {
   grid-column: 3 / span 1;
 }
 
-.w-100p {
+.ps-flex {
+  display: flex;
+}
+
+.ps-column {
+  flex-direction: column;
+}
+
+.ps-jc-spb {
+  justify-content: space-between;
+}
+
+.ps-ai-c {
+  align-items: center;
+}
+
+.ps-w-100p {
   width: 100%;
 }
 
-.w-84p {
+.ps-w-84p {
   width: 84%;
 }
 
-.pos-rel {
+.ps-w-90vw {
+  width: 90vw;
+}
+
+.ps-h-100p {
+  height: 100%;
+}
+
+.ps-mxh-230px {
+  max-height: 230px;
+}
+
+.ps-mxh-30px {
+  max-height: 30px;
+}
+
+.ps-pos-rel {
   position: relative;
 }
 
-.ofl-hidden {
+.ps-ofl-hidden {
   overflow: hidden;
 }
 
-.bgcol-bg {
+.ps-bgcol-bg {
   background-color: var(--color-background);
 }
 
-.col-fg {
+.ps-col-fg {
   color: var(--color-foreground);
 }
 
-.mx-auto {
+.ps-mb-5 {
+  margin-bottom: 16px;
+}
+
+.ps-mx-auto {
   margin-left: auto;
   margin-right: auto;
 }
 
-.pb-11 {
+.ps-pb-11 {
   padding-bottom: 56px;
 }
 
-.pt-0 {
+.ps-pt-0 {
   padding-top: 0;
 }
 
-.pt-9 {
+.ps-pt-9 {
   padding-top: 40px;
 }
 
-.px-2p {
+.ps-px-2p {
   padding-left: 2%;
   padding-right: 2%;
 }
 
-.ff-heading {
+.ps-px-38px {
+  padding-left: 38px;
+  padding-right: 38px;
+}
+
+.ps-py-8 {
+  padding-top: 32px;
+  padding-bottom: 32px;
+}
+
+.ps-ff-heading {
   font-family: var(--font-heading-family);
 }
 
-.fs-7 {
+.ps-fs-0 {
+  font-size: 14px;
+}
+
+.ps-fs-7 {
   font-size: 28px;
 }
 
-.lh-30px {
+.ps-lh-30px {
   line-height: 30px;
 }
 
-.ls-m124 {
+.ps-lh-130 {
+  line-height: 130%;
+}
+
+.ps-ls-m124 {
   letter-spacing: -1.24px;
 }
 
-.fw-500 {
+.ps-fw-300 {
+  font-weight: 300;
+}
+
+.ps-fw-500 {
   font-weight: 500;
 }
 
-.ta-c {
+.ps-ta-c {
   text-align: center;
 }
 
+.ps-noborder {
+  border: none;
+}
+
+.ps-noborder:active {
+  border: none;
+}
+
+.ps-noborder:focus {
+  border: none;
+}
+
+.ps-nooutline {
+  outline: none;
+}
+
+.ps-nooutline:active {
+  outline: none;
+}
+
+.ps-nooutline:focus {
+  outline: none;
+}
+
 @media screen and (min-width: 500px) {
-  .w-md-74p {
+  .ps-w-md-85p {
+    width: 85%;
+  }
+  .ps-w-md-74p {
     width: 74%;
   }
-  .pb-md-12 {
+  .ps-mnh-md-230px {
+    min-height: 230px;
+  }
+  .ps-mb-md-15px {
+    margin-bottom: 15px;
+  }
+  .ps-pb-md-12 {
     padding-bottom: 64px;
   }
-  .pt-md-7 {
+  .ps-pt-md-7 {
     padding-top: 24px;
   }
-  .px-md-3p {
+  .ps-px-md-3p {
     padding-left: 3%;
     padding-right: 3%;
+  }
+  .ps-px-md-11 {
+    padding-left: 56px;
+    padding-right: 56px;
+  }
+  .ps-py-md-13 {
+    padding-top: 72px;
+    padding-bottom: 72px;
+  }
+  .ps-fs-md-4 {
+    font-size: 22px;
   }
 }
 
 @media screen and (min-width: 990px) {
-  .SectionGrid {
+  .ps-SectionGrid {
     display: grid;
   }
-  .w-lg-auto {
+  .ps-w-lg-auto {
     width: auto;
   }
-  .pb-lg-10 {
+  .ps-mb-md-18px {
+    margin-bottom: 18px;
+  }
+  .ps-pb-lg-10 {
     padding-bottom: 48px;
   }
-  .pt-lg-10 {
+  .ps-pt-lg-10 {
     padding-top: 48px;
   }
-  .fs-lg-38px {
+  .ps-fs-lg-38px {
     font-style: 38px;
   }
-  .lh-lg-44px {
+  .ps-lh-lg-44px {
     line-height: 44px;
   }
-  .fw-lg-400 {
+  .ps-fs-lg-2 {
+    font-size: 16px;
+  }
+  .ps-lh-lg-140 {
+    line-height: 140%;
+  }
+  .ps-fw-lg-400 {
     font-weight: 400;
   }
 }

--- a/assets/presseslider.css
+++ b/assets/presseslider.css
@@ -19,6 +19,13 @@
   display: flex !important;
 }
 
+sleepink-slider .slider-buttons {
+  position: absolute;
+  z-index: 2;
+  right: 0;
+  bottom: 0;
+}
+
 /* Own styles, prefixed with ps- */
 
 .ps-mobile {

--- a/assets/presseslider.css
+++ b/assets/presseslider.css
@@ -1,0 +1,120 @@
+.SectionGrid {
+  display: block;
+  grid-template-columns:
+    1fr minmax(25px, 200px) minmax(700px, 900px) minmax(25px, 200px)
+    1fr;
+}
+
+.SectionGrid-Narrow {
+  grid-column: 3 / span 1;
+}
+
+.w-100p {
+  width: 100%;
+}
+
+.w-84p {
+  width: 84%;
+}
+
+.pos-rel {
+  position: relative;
+}
+
+.ofl-hidden {
+  overflow: hidden;
+}
+
+.bgcol-bg {
+  background-color: var(--color-background);
+}
+
+.col-fg {
+  color: var(--color-foreground);
+}
+
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.pb-11 {
+  padding-bottom: 56px;
+}
+
+.pt-0 {
+  padding-top: 0;
+}
+
+.pt-9 {
+  padding-top: 40px;
+}
+
+.px-2p {
+  padding-left: 2%;
+  padding-right: 2%;
+}
+
+.ff-heading {
+  font-family: var(--font-heading-family);
+}
+
+.fs-7 {
+  font-size: 28px;
+}
+
+.lh-30px {
+  line-height: 30px;
+}
+
+.ls-m124 {
+  letter-spacing: -1.24px;
+}
+
+.fw-500 {
+  font-weight: 500;
+}
+
+.ta-c {
+  text-align: center;
+}
+
+@media screen and (min-width: 500px) {
+  .w-md-74p {
+    width: 74%;
+  }
+  .pb-md-12 {
+    padding-bottom: 64px;
+  }
+  .pt-md-7 {
+    padding-top: 24px;
+  }
+  .px-md-3p {
+    padding-left: 3%;
+    padding-right: 3%;
+  }
+}
+
+@media screen and (min-width: 990px) {
+  .SectionGrid {
+    display: grid;
+  }
+  .w-lg-auto {
+    width: auto;
+  }
+  .pb-lg-10 {
+    padding-bottom: 48px;
+  }
+  .pt-lg-10 {
+    padding-top: 48px;
+  }
+  .fs-lg-38px {
+    font-style: 38px;
+  }
+  .lh-lg-44px {
+    line-height: 44px;
+  }
+  .fw-lg-400 {
+    font-weight: 400;
+  }
+}

--- a/assets/presseslider.css
+++ b/assets/presseslider.css
@@ -1,3 +1,34 @@
+/* Slider settings */
+
+.slider.slider--desktop {
+  position: relative;
+  flex-wrap: inherit;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  scroll-padding-left: 1rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+.slider.slider--desktop .slider__slide {
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.slider-buttons {
+  display: flex !important;
+}
+
+/* Own styles, prefixed with ps- */
+
+.ps-mobile {
+  display: block;
+}
+
+.ps-nmobile {
+  display: none;
+}
+
 .ps-SectionGrid {
   display: block;
   grid-template-columns:
@@ -39,6 +70,10 @@
 
 .ps-h-100p {
   height: 100%;
+}
+
+.ps-mxw-100p {
+  max-width: 100%;
 }
 
 .ps-mxh-230px {
@@ -162,6 +197,12 @@
 }
 
 @media screen and (min-width: 500px) {
+  .ps-mobile {
+    display: none;
+  }
+  .ps-nmobile {
+    display: block;
+  }
   .ps-w-md-85p {
     width: 85%;
   }

--- a/assets/sleepink-slider.js
+++ b/assets/sleepink-slider.js
@@ -1,0 +1,72 @@
+class SleepinkSlider extends HTMLElement {
+  constructor() {
+    super()
+    this.slider = this.querySelector("ul")
+    this.sliderItems = this.querySelectorAll("li")
+    this.pageCount = this.querySelector(".slider-counter--current")
+    this.pageTotal = this.querySelector(".slider-counter--total")
+    this.prevButton = this.querySelector('button[name="previous"]')
+    this.nextButton = this.querySelector('button[name="next"]')
+
+    if (!this.slider || !this.nextButton) return
+
+    const resizeObserver = new ResizeObserver((entries) => this.initPages())
+    resizeObserver.observe(this.slider)
+
+    this.slider.addEventListener("scroll", this.update.bind(this))
+    this.prevButton.addEventListener("click", this.onButtonClick.bind(this))
+    this.nextButton.addEventListener("click", this.onButtonClick.bind(this))
+  }
+
+  initPages() {
+    if (!this.sliderItems.length === 0) return
+    this.slidesPerPage = Math.floor(
+      this.slider.clientWidth / this.sliderItems[0].clientWidth
+    )
+    this.totalPages = this.sliderItems.length - this.slidesPerPage + 1
+    this.update()
+  }
+
+  update() {
+    if (!this.pageCount || !this.pageTotal) return
+    this.currentPage =
+      Math.round(this.slider.scrollLeft / this.sliderItems[0].clientWidth) + 1
+
+    // if (this.currentPage === 1) {
+    //   this.prevButton.setAttribute("disabled", true)
+    // } else {
+    this.prevButton.removeAttribute("disabled")
+    // }
+
+    // if (this.currentPage === this.totalPages) {
+    //   this.nextButton.setAttribute("disabled", true)
+    // } else {
+    this.nextButton.removeAttribute("disabled")
+    // }
+
+    this.pageCount.textContent = this.currentPage
+    this.pageTotal.textContent = this.totalPages
+  }
+
+  onButtonClick(event) {
+    event.preventDefault()
+    this.currentPage =
+      Math.round(this.slider.scrollLeft / this.sliderItems[0].clientWidth) + 1
+    this.totalPages = this.sliderItems.length - this.slidesPerPage + 1
+    const slideScrollPosition =
+      event.currentTarget.name === "next"
+        ? this.currentPage === this.totalPages
+          ? this.slider.scrollLeft -
+            (this.totalPages - 1) * this.sliderItems[0].clientWidth
+          : this.slider.scrollLeft + this.sliderItems[0].clientWidth
+        : this.currentPage === 1
+        ? this.slider.scrollLeft +
+          (this.totalPages - 1) * this.sliderItems[0].clientWidth
+        : this.slider.scrollLeft - this.sliderItems[0].clientWidth
+    this.slider.scrollTo({
+      left: slideScrollPosition,
+    })
+  }
+}
+
+customElements.define("sleepink-slider", SleepinkSlider)

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -118,6 +118,7 @@
     <main id="MainContent" class="content-for-layout focus-none" role="main" tabindex="-1">
       {{ content_for_layout }}
     </main>
+    {% section 'presseslider' %}
 
     {% section 'sleepink-footer' %}
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -118,7 +118,6 @@
     <main id="MainContent" class="content-for-layout focus-none" role="main" tabindex="-1">
       {{ content_for_layout }}
     </main>
-    {% section 'presseslider' %}
 
     {% section 'sleepink-footer' %}
 

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -145,6 +145,7 @@
     </script>
 
     <script src="{{ 'slider.js' | asset_url }}" defer="defer"></script>
+    <script src="{{ 'sleepink-slider.js' | asset_url }}" defer="defer"></script>
     <script src="{{ 'variants.js' | asset_url }}" defer="defer"></script>
   </body>
 </html>

--- a/sections/123.liquid
+++ b/sections/123.liquid
@@ -7,6 +7,8 @@
             src="{{ 'leaf-left.png' | asset_img_url: '600x' }}"
             alt="{{ "Decorative Leaf" }}"
             loading="lazy"
+            width="570"
+            height="600"
             >
         </div>
     {%- endif -%}
@@ -36,6 +38,8 @@
             src="{{ 'leaf-right.png' | asset_img_url: '600x' }}"
             alt="{{ "Decorative Leaf" }}"
             loading="lazy"
+            width="570"
+            height="400"
             >
         </div>
     {%- endif -%}

--- a/sections/presse-logos.liquid
+++ b/sections/presse-logos.liquid
@@ -11,7 +11,13 @@
       {% for block in section.blocks %}
         {% assign bSettings = block.settings %}
         {% if bSettings.showMobile %}
-        <img src="{{ bSettings.image | img_url: 'x36' }}" alt="{{ bSettings.image.alt | escape }}" loading="lazy" height="18px" />
+        <img 
+          src="{{ bSettings.image | img_url: 'x36' }}" 
+          alt="{{ bSettings.image.alt | escape }}" 
+          loading="lazy" 
+          height="18"
+          width="90" 
+        />
         {% endif %}
       {% endfor %}
     </div>
@@ -24,7 +30,13 @@
       {% for block in section.blocks %}
         {% assign bSettings = block.settings %}
         {% if bSettings.showDesktop %}
-        <img src="{{ bSettings.image | img_url: 'x82' }}" alt="{{ bSettings.image.alt | escape }}" loading="lazy" height="41px" />
+        <img 
+          src="{{ bSettings.image | img_url: 'x82' }}" 
+          alt="{{ bSettings.image.alt | escape }}" 
+          loading="lazy" 
+          height="41" 
+          width="205"
+        />
         {% endif %}
       {% endfor %}
     </div>

--- a/sections/presseslider.liquid
+++ b/sections/presseslider.liquid
@@ -66,6 +66,8 @@
                         src="{{ article.settings.image | img_url: 'x30' }}" 
                         alt="{{ article.settings.image.alt }}" 
                         class="ps-contain ps-w-100p ps-h-100p"
+                        width="150"
+                        height="30"
                         loading="lazy"
                       >
                     </div>

--- a/sections/presseslider.liquid
+++ b/sections/presseslider.liquid
@@ -1,0 +1,170 @@
+<link rel="stylesheet" href="{{ 'component-slider.css' | asset_url }}" media="print" onload="this.media='all'">
+<link rel="stylesheet" href="{{ 'component-price.css' | asset_url }}" media="print" onload="this.media='all'">
+<link rel="stylesheet" href="{{ 'component-badge.css' | asset_url }}" media="print" onload="this.media='all'">
+<link rel="stylesheet" href="{{ 'template-collection.css' | asset_url }}" media="print" onload="this.media='all'">
+
+<noscript>{{ 'component-slider.css' | asset_url | stylesheet_tag }}</noscript>
+<noscript>{{ 'component-price.css' | asset_url | stylesheet_tag }}</noscript>
+<noscript>{{ 'component-badge.css' | asset_url | stylesheet_tag }}</noscript>
+<noscript>{{ 'template-collection.css' | asset_url | stylesheet_tag }}</noscript>
+
+{{ 'component-card.css' | asset_url | stylesheet_tag }}
+{{ 'presseslider.css' | asset_url | stylesheet_tag }}
+
+<div class="SectionGrid ofl-hidden pos-rel w-100p bgcol-bg px-2p px-md-3p pt-9 pt-md-7 pt-lg-10 pb-11 pb-md-12 pb-lg-10">
+  <div class="SectionGrid-Narrow bgcol-bg">
+    <h3 class="ff-heading col-fg fs-7 fs-lg-38px lh-30px lh-lg-44px ls-m124 fw-500 fw-lg-400 mx-auto mb-8 pt-0 ta-c w-84p w-md-74p w-lg-auto">Hier könnte Ihr Titel stehen</h3>
+  </div>
+</div>
+
+<div class="collection page-width{% if section.settings.swipe_on_mobile == true and section.settings.collection.all_products_count > 2 and section.settings.products_to_show > 2 %} page-width-desktop{% endif %}">
+  <div class="{% if section.settings.show_view_all and section.settings.swipe_on_mobile %}title-wrapper-with-link{% endif %}{% if section.settings.title == blank %} title-wrapper-with-link--no-heading{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} title-wrapper--self-padded-tablet-down{% endif %}">
+    <h2 class="title{% if section.settings.title == blank %} title--no-heading{% endif %}">{{ section.settings.title | escape }}</h2>
+
+    {%- if section.settings.show_view_all and section.settings.swipe_on_mobile -%}
+      <a href="{{ section.settings.collection.url }}" class="link underlined-link large-up-hide">{{ 'sections.featured_collection.view_all' | t }}</a>
+    {%- endif -%}
+  </div>
+
+  {%- liquid
+    assign products_to_display = section.settings.collection.all_products_count
+
+    if section.settings.collection.all_products_count > section.settings.products_to_show
+      assign products_to_display = section.settings.products_to_show
+    endif
+  %}
+
+  <slider-component class="slider-mobile-gutter">
+    <ul class="grid grid--2-col{% if products_to_display == 4 or section.settings.collection == blank %} grid--2-col-tablet grid--4-col-desktop{% else %} grid--3-col-tablet{% endif %}{% if products_to_display > 5 %} grid--one-third-max grid--4-col-desktop grid--quarter-max{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider slider--tablet grid--peek{% endif %}{% if section.settings.show_view_all == false or section.settings.collection.products.size < section.settings.products_to_show %} negative-margin{% endif %}{% if section.settings.show_view_all and section.settings.collection.products.size > section.settings.products_to_show %} negative-margin--small{% endif %}" role="list">
+      {%- for product in section.settings.collection.products limit: section.settings.products_to_show -%}
+        <li class="grid__item{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider__slide{% endif %}">
+          {% render 'product-card',
+            product_card_product: product,
+            media_size: section.settings.image_ratio,
+            show_secondary_image: section.settings.show_secondary_image,
+            add_image_padding: section.settings.add_image_padding,
+            show_vendor: section.settings.show_vendor
+          %}
+        </li>
+      {%- else -%}
+        {%- for i in (1..4) -%}
+          <li class="grid__item">
+            {% render 'product-card-placeholder' %}
+          </li>
+        {%- endfor -%}
+      {%- endfor -%}
+    </ul>
+    {%- if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 -%}
+      <div class="slider-buttons no-js-hidden{% if section.settings.collection.all_products_count < 4 %} medium-hide{% endif %}{% if section.settings.collection.all_products_count < 3 %} small-hide{% endif %}">
+        <div class="slider-counter caption">
+          <span class="slider-counter--current">1</span>
+          <span aria-hidden="true"> / </span>
+          <span class="visually-hidden">{{ 'accessibility.of' | t }}</span>
+          <span class="slider-counter--total">{{ products_to_display }}</span>
+        </div>
+        <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
+        <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
+      </div>
+    {%- endif -%}
+  </slider-component>
+
+  {%- if section.settings.show_view_all and section.settings.collection.all_products_count > section.settings.products_to_show -%}
+    <div class="center{% if section.settings.swipe_on_mobile %} small-hide medium-hide{% endif %}">
+      <a href="{{ section.settings.collection.url }}"
+        class="button"
+        aria-label="{{ 'sections.featured_collection.view_all_label' | t: collection_name: section.settings.collection.title }}"
+      >
+        {{ 'sections.featured_collection.view_all' | t }}
+      </a>
+    </div>
+  {%- endif -%}
+</div>
+
+{% schema %}
+{
+  "name": "t:sections.featured-collection.name",
+  "tag": "section",
+  "class": "spaced-section",
+  "settings": [
+    {
+      "type": "text",
+      "id": "title",
+      "default": "Featured collection",
+      "label": "t:sections.featured-collection.settings.title.label"
+    },
+    {
+      "type": "collection",
+      "id": "collection",
+      "label": "t:sections.featured-collection.settings.collection.label"
+    },
+    {
+      "type": "range",
+      "id": "products_to_show",
+      "min": 2,
+      "max": 12,
+      "step": 2,
+      "default": 4,
+      "label": "t:sections.featured-collection.settings.products_to_show.label"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_view_all",
+      "default": true,
+      "label": "t:sections.featured-collection.settings.show_view_all.label"
+    },
+    {
+      "type": "checkbox",
+      "id": "swipe_on_mobile",
+      "default": false,
+      "label": "t:sections.featured-collection.settings.swipe_on_mobile.label"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.featured-collection.settings.header.content"
+    },
+    {
+      "type": "select",
+      "id": "image_ratio",
+      "options": [
+        {
+          "value": "adapt",
+          "label": "t:sections.featured-collection.settings.image_ratio.options__1.label"
+        },
+        {
+          "value": "portrait",
+          "label": "t:sections.featured-collection.settings.image_ratio.options__2.label"
+        },
+        {
+          "value": "square",
+          "label": "t:sections.featured-collection.settings.image_ratio.options__3.label"
+        }
+      ],
+      "default": "adapt",
+      "label": "t:sections.featured-collection.settings.image_ratio.label"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_secondary_image",
+      "default": false,
+      "label": "t:sections.featured-collection.settings.show_secondary_image.label"
+    },
+    {
+      "type": "checkbox",
+      "id": "add_image_padding",
+      "default": false,
+      "label": "t:sections.featured-collection.settings.add_image_padding.label"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_vendor",
+      "default": false,
+      "label": "t:sections.featured-collection.settings.show_vendor.label"
+    }
+  ],
+  "presets": [
+    {
+      "name": "t:sections.featured-collection.presets.name"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/presseslider.liquid
+++ b/sections/presseslider.liquid
@@ -14,7 +14,7 @@
           <slider-component class="slider-mobile-gutter">
             <ul class="grid slider slider--tablet grid--peek negative-margin negative-margin--small" role="list">
               {%- for article in articles -%}
-                <li class="slider__slide">
+                <li class="slider__slide w-100p">
                   <div class="ps-flex ps-column ps-jc-spb ps-ai-c ps-w-90vw ps-w-md-85p ps-mxh-230px ps-mnh-md-230px ps-px-38px ps-px-md-11 ps-py-8 ps-py-md-13 ps-mx-auto ps-ta-c">
                     <h4 class="ps-ff-heading ps-fs-0 ps-fs-md-4 ps-fs-lg-2 ps-fw-300 ps-lh-130 ps-lh-lg-140 ps-mb-5 ps-mb-md-15px ps-mb-lg-18px ps-col-fg">
                       {{ article.settings.text }}

--- a/sections/presseslider.liquid
+++ b/sections/presseslider.liquid
@@ -1,21 +1,14 @@
+{{ 'presseslider.css' | asset_url | stylesheet_tag }}
 <link rel="stylesheet" href="{{ 'component-slider.css' | asset_url }}" media="print" onload="this.media='all'">
-<link rel="stylesheet" href="{{ 'component-price.css' | asset_url }}" media="print" onload="this.media='all'">
-<link rel="stylesheet" href="{{ 'component-badge.css' | asset_url }}" media="print" onload="this.media='all'">
-<link rel="stylesheet" href="{{ 'template-collection.css' | asset_url }}" media="print" onload="this.media='all'">
 
 <noscript>{{ 'component-slider.css' | asset_url | stylesheet_tag }}</noscript>
-<noscript>{{ 'component-price.css' | asset_url | stylesheet_tag }}</noscript>
-<noscript>{{ 'component-badge.css' | asset_url | stylesheet_tag }}</noscript>
-<noscript>{{ 'template-collection.css' | asset_url | stylesheet_tag }}</noscript>
-
-{{ 'component-card.css' | asset_url | stylesheet_tag }}
-{{ 'presseslider.css' | asset_url | stylesheet_tag }}
 
 <div class="ps-SectionGrid ps-ofl-hidden ps-pos-rel ps-w-100p ps-bgcol-bg ps-px-2p ps-px-md-3p ps-pt-9 ps-pt-md-7 ps-pt-lg-10 ps-pb-11 ps-pb-md-12 ps-pb-lg-10">
   <div class="ps-SectionGrid-Narrow ps-bgcol-bg">
     <h3 class="ps-ff-heading ps-col-fg ps-fs-7 ps-fs-lg-38px ps-lh-30px ps-lh-lg-44px ps-ls-m124 ps-fw-500 ps-fw-lg-400 ps-mx-auto ps-mb-8 ps-pt-0 ps-ta-c ps-w-84p ps-w-md-74p ps-w-lg-auto">{{ section.settings.title }}</h3>
     <div>
-      <div class="ps-w-100p ps-h-100p ps-noborder ps-nooutline">
+      {% comment %} Mobile Slider {% endcomment %}
+      <div class="ps-w-100p ps-h-100p ps-noborder ps-nooutline ps-mobile">
         <div class="collection page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}">
           {% assign articles = section.blocks | where: 'type', 'image' %}
           <slider-component class="slider-mobile-gutter">
@@ -53,6 +46,47 @@
           </slider-component>
         </div>
       </div>
+      {% comment %} End of Mobile Slider {% endcomment %}
+      {% comment %} Tablet and Desktop Slider {% endcomment %}
+      <div class="ps-nmobile ps-w-100p ps-h-100p ps-noborder ps-nooutline">
+        <div class="collection page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}">
+          {% assign articles = section.blocks | where: 'type', 'image' %}
+          <slider-component class="slider-mobile-gutter">
+            <ul class="grid slider slider--desktop slider--tablet grid--peek negative-margin negative-margin--small" role="list">
+              {%- for article in articles -%}
+                <li class="slider__slide ps-mxw-100p">
+                  <div class="ps-flex ps-column ps-jc-spb ps-ai-c ps-w-90vw ps-w-md-85p ps-mxh-230px ps-mnh-md-230px ps-px-38px ps-px-md-11 ps-py-8 ps-py-md-13 ps-mx-auto ps-ta-c">
+                    <h4 class="ps-ff-heading ps-fs-0 ps-fs-md-4 ps-fs-lg-2 ps-fw-300 ps-lh-130 ps-lh-lg-140 ps-mb-5 ps-mb-md-15px ps-mb-lg-18px">
+                      {{ article.settings.text }}
+                    </h4>
+                    <div class="ps-mxh-30px ps-mxw-80p ps-mnw-50p ps-mt-8 ps-mr-0">
+                      <img 
+                        src="{{ article.settings.image | img_url: 'x30' }}" 
+                        alt="{{ article.settings.image.alt }}" 
+                        class="ps-contain ps-w-100p ps-h-100p"
+                        loading="lazy"
+                      >
+                    </div>
+                  </div>
+                </li>
+              {%- endfor -%}
+            </ul>
+            {%- if articles.size > 1 and section.settings.swipe_on_mobile -%}
+              <div class="slider-buttons no-js-hidden">
+                <div class="slider-counter caption">
+                  <span class="slider-counter--current">1</span>
+                  <span aria-hidden="true"> / </span>
+                  <span class="visually-hidden">{{ 'accessibility.of' | t }}</span>
+                  <span class="slider-counter--total">{{ articles.size }}</span>
+                </div>
+                <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
+                <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
+              </div>
+            {%- endif -%}
+          </slider-component>
+        </div>
+      </div>
+      {% comment %} End of Tablet and Desktop Slider {% endcomment %}
     </div>
   </div>
 </div>

--- a/sections/presseslider.liquid
+++ b/sections/presseslider.liquid
@@ -11,32 +11,26 @@
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'presseslider.css' | asset_url | stylesheet_tag }}
 
-<div class="SectionGrid ofl-hidden pos-rel w-100p bgcol-bg px-2p px-md-3p pt-9 pt-md-7 pt-lg-10 pb-11 pb-md-12 pb-lg-10">
-  <div class="SectionGrid-Narrow bgcol-bg">
-    <h3 class="ff-heading col-fg fs-7 fs-lg-38px lh-30px lh-lg-44px ls-m124 fw-500 fw-lg-400 mx-auto mb-8 pt-0 ta-c w-84p w-md-74p w-lg-auto">Hier könnte Ihr Titel stehen</h3>
+<div class="ps-SectionGrid ps-ofl-hidden ps-pos-rel ps-w-100p ps-bgcol-bg ps-px-2p ps-px-md-3p ps-pt-9 ps-pt-md-7 ps-pt-lg-10 ps-pb-11 ps-pb-md-12 ps-pb-lg-10">
+  <div class="ps-SectionGrid-Narrow ps-bgcol-bg">
+    <h3 class="ps-ff-heading ps-col-fg ps-fs-7 ps-fs-lg-38px ps-lh-30px ps-lh-lg-44px ps-ls-m124 ps-fw-500 ps-fw-lg-400 ps-mx-auto ps-mb-8 ps-pt-0 ps-ta-c ps-w-84p ps-w-md-74p ps-w-lg-auto">{{ section.settings.title }}</h3>
     <div>
-      <div class="w-100p h-100p noborder nooutline">
+      <div class="ps-w-100p ps-h-100p ps-noborder ps-nooutline">
         <div class="collection page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}">
-          <div class="title-wrapper-with-link title-wrapper-with-link--no-heading title-wrapper--self-padded-tablet-down">
-            <h2 class="title title--no-heading">{{ section.settings.title | escape }}</h2>
-              {%- if section.settings.swipe_on_mobile -%}
-                <a href="{{ section.settings.collection.url }}" class="link underlined-link large-up-hide">{{ 'sections.featured_collection.view_all' | t }}</a>
-              {%- endif -%}
-          </div>
           {% assign articles = section.blocks | where: 'type', 'image' %}
           <slider-component class="slider-mobile-gutter">
             <ul class="grid slider slider--tablet grid--peek negative-margin negative-margin--small" role="list">
               {%- for article in articles -%}
                 <li class="slider__slide">
-                  <div class="flex column jc-spb ai-c w-90vw w-md-85p mxh-230px mnh-md-230px px-38px px-md-11 py-8 py-md-13 mx-auto ta-c">
-                    <h4 class="ff-heading fs-0 fs-md-4 fs-lg-2 fw-300 lh-130 lh-lg-140 mb-5 mb-md-15px mb-lg-18px">
+                  <div class="ps-flex ps-column ps-jc-spb ps-ai-c ps-w-90vw ps-w-md-85p ps-mxh-230px ps-mnh-md-230px ps-px-38px ps-px-md-11 ps-py-8 ps-py-md-13 ps-mx-auto ps-ta-c">
+                    <h4 class="ps-ff-heading ps-fs-0 ps-fs-md-4 ps-fs-lg-2 ps-fw-300 ps-lh-130 ps-lh-lg-140 ps-mb-5 ps-mb-md-15px ps-mb-lg-18px">
                       {{ article.settings.text }}
                     </h4>
-                    <div class="mxh-30px mxw-80p mnw-50p mt-8 mr-0">
+                    <div class="ps-mxh-30px ps-mxw-80p ps-mnw-50p ps-mt-8 ps-mr-0">
                       <img 
-                        src="{{ article.settings.image | img_url }}" 
+                        src="{{ article.settings.image | img_url: 'x30' }}" 
                         alt="{{ article.settings.image.alt }}" 
-                        class="contain w-100p h-100p"
+                        class="ps-contain ps-w-100p ps-h-100p"
                         loading="lazy"
                       >
                     </div>
@@ -45,7 +39,7 @@
               {%- endfor -%}
             </ul>
             {%- if articles.size > 1 and section.settings.swipe_on_mobile -%}
-              <div class="slider-buttons no-js-hidden{% if section.settings.collection.all_products_count < 4 %} medium-hide{% endif %}{% if section.settings.collection.all_products_count < 3 %} small-hide{% endif %}">
+              <div class="slider-buttons no-js-hidden">
                 <div class="slider-counter caption">
                   <span class="slider-counter--current">1</span>
                   <span aria-hidden="true"> / </span>

--- a/sections/presseslider.liquid
+++ b/sections/presseslider.liquid
@@ -3,7 +3,7 @@
 
 <noscript>{{ 'component-slider.css' | asset_url | stylesheet_tag }}</noscript>
 
-<div class="ps-SectionGrid ps-ofl-hidden ps-pos-rel ps-w-100p ps-bgcol-bg ps-px-2p ps-px-md-3p ps-pt-9 ps-pt-md-7 ps-pt-lg-10 ps-pb-11 ps-pb-md-12 ps-pb-lg-10">
+<div class="ps-SectionGrid ps-ofl-hidden ps-pos-rel ps-w-100p ps-bgcol-bg ps-px-2p ps-px-md-3p ps-pt-9 ps-pt-md-7 ps-pt-lg-10 ps-pb-11 ps-pb-md-12 ps-pb-lg-10 color-{{ section.settings.color_scheme }}">
   <div class="ps-SectionGrid-Narrow ps-bgcol-bg">
     <h3 class="ps-ff-heading ps-col-fg ps-fs-7 ps-fs-lg-38px ps-lh-30px ps-lh-lg-44px ps-ls-m124 ps-fw-500 ps-fw-lg-400 ps-mx-auto ps-mb-8 ps-pt-0 ps-ta-c ps-w-84p ps-w-md-74p ps-w-lg-auto">{{ section.settings.title }}</h3>
     <div>
@@ -16,7 +16,7 @@
               {%- for article in articles -%}
                 <li class="slider__slide">
                   <div class="ps-flex ps-column ps-jc-spb ps-ai-c ps-w-90vw ps-w-md-85p ps-mxh-230px ps-mnh-md-230px ps-px-38px ps-px-md-11 ps-py-8 ps-py-md-13 ps-mx-auto ps-ta-c">
-                    <h4 class="ps-ff-heading ps-fs-0 ps-fs-md-4 ps-fs-lg-2 ps-fw-300 ps-lh-130 ps-lh-lg-140 ps-mb-5 ps-mb-md-15px ps-mb-lg-18px">
+                    <h4 class="ps-ff-heading ps-fs-0 ps-fs-md-4 ps-fs-lg-2 ps-fw-300 ps-lh-130 ps-lh-lg-140 ps-mb-5 ps-mb-md-15px ps-mb-lg-18px ps-col-fg">
                       {{ article.settings.text }}
                     </h4>
                     <div class="ps-mxh-30px ps-mxw-80p ps-mnw-50p ps-mt-8 ps-mr-0">
@@ -109,6 +109,34 @@
       "id": "swipe_on_mobile",
       "default": true,
       "label": "Swipen auf Mobilgeräten erlaubt"
+    },
+    {
+      "type": "select",
+      "id": "color_scheme",
+      "options": [
+        {
+          "value": "accent-1",
+          "label": "t:sections.footer.settings.color_scheme.options__1.label"
+        },
+        {
+          "value": "accent-2",
+          "label": "t:sections.footer.settings.color_scheme.options__2.label"
+        },
+        {
+          "value": "background-1",
+          "label": "t:sections.footer.settings.color_scheme.options__3.label"
+        },
+        {
+          "value": "background-2",
+          "label": "t:sections.footer.settings.color_scheme.options__4.label"
+        },
+        {
+          "value": "inverse",
+          "label": "t:sections.footer.settings.color_scheme.options__5.label"
+        }
+      ],
+      "default": "background-1",
+      "label": "t:sections.footer.settings.color_scheme.label"
     }
   ],
   "blocks": [
@@ -119,7 +147,7 @@
         {
           "type": "image_picker",
           "id": "image",
-          "label": "Image"
+          "label": "Logo der Quelle"
         },
         {
           "id": "text",

--- a/sections/presseslider.liquid
+++ b/sections/presseslider.liquid
@@ -11,7 +11,7 @@
       <div class="ps-w-100p ps-h-100p ps-noborder ps-nooutline ps-mobile">
         <div class="collection page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}">
           {% assign articles = section.blocks | where: 'type', 'image' %}
-          <slider-component class="slider-mobile-gutter">
+          <sleepink-slider class="slider-mobile-gutter">
             <ul class="grid slider slider--tablet grid--peek negative-margin negative-margin--small" role="list">
               {%- for article in articles -%}
                 <li class="slider__slide w-100p">
@@ -45,7 +45,7 @@
                 <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
               </div>
             {%- endif -%}
-          </slider-component>
+          </sleepink-slider>
         </div>
       </div>
       {% comment %} End of Mobile Slider {% endcomment %}
@@ -53,7 +53,7 @@
       <div class="ps-nmobile ps-w-100p ps-h-100p ps-noborder ps-nooutline">
         <div class="collection page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}">
           {% assign articles = section.blocks | where: 'type', 'image' %}
-          <slider-component class="slider-mobile-gutter">
+          <sleepink-slider class="slider-mobile-gutter">
             <ul class="grid slider slider--desktop slider--tablet grid--peek negative-margin negative-margin--small" role="list">
               {%- for article in articles -%}
                 <li class="slider__slide ps-mxw-100p">
@@ -87,7 +87,7 @@
                 <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
               </div>
             {%- endif -%}
-          </slider-component>
+          </sleepink-slider>
         </div>
       </div>
       {% comment %} End of Tablet and Desktop Slider {% endcomment %}

--- a/sections/presseslider.liquid
+++ b/sections/presseslider.liquid
@@ -23,6 +23,8 @@
                       <img 
                         src="{{ article.settings.image | img_url: 'x30' }}" 
                         alt="{{ article.settings.image.alt }}" 
+                        width="150"
+                        height="30"
                         class="ps-contain ps-w-100p ps-h-100p"
                         loading="lazy"
                       >

--- a/sections/presseslider.liquid
+++ b/sections/presseslider.liquid
@@ -14,156 +14,106 @@
 <div class="SectionGrid ofl-hidden pos-rel w-100p bgcol-bg px-2p px-md-3p pt-9 pt-md-7 pt-lg-10 pb-11 pb-md-12 pb-lg-10">
   <div class="SectionGrid-Narrow bgcol-bg">
     <h3 class="ff-heading col-fg fs-7 fs-lg-38px lh-30px lh-lg-44px ls-m124 fw-500 fw-lg-400 mx-auto mb-8 pt-0 ta-c w-84p w-md-74p w-lg-auto">Hier könnte Ihr Titel stehen</h3>
-  </div>
-</div>
-
-<div class="collection page-width{% if section.settings.swipe_on_mobile == true and section.settings.collection.all_products_count > 2 and section.settings.products_to_show > 2 %} page-width-desktop{% endif %}">
-  <div class="{% if section.settings.show_view_all and section.settings.swipe_on_mobile %}title-wrapper-with-link{% endif %}{% if section.settings.title == blank %} title-wrapper-with-link--no-heading{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} title-wrapper--self-padded-tablet-down{% endif %}">
-    <h2 class="title{% if section.settings.title == blank %} title--no-heading{% endif %}">{{ section.settings.title | escape }}</h2>
-
-    {%- if section.settings.show_view_all and section.settings.swipe_on_mobile -%}
-      <a href="{{ section.settings.collection.url }}" class="link underlined-link large-up-hide">{{ 'sections.featured_collection.view_all' | t }}</a>
-    {%- endif -%}
-  </div>
-
-  {%- liquid
-    assign products_to_display = section.settings.collection.all_products_count
-
-    if section.settings.collection.all_products_count > section.settings.products_to_show
-      assign products_to_display = section.settings.products_to_show
-    endif
-  %}
-
-  <slider-component class="slider-mobile-gutter">
-    <ul class="grid grid--2-col{% if products_to_display == 4 or section.settings.collection == blank %} grid--2-col-tablet grid--4-col-desktop{% else %} grid--3-col-tablet{% endif %}{% if products_to_display > 5 %} grid--one-third-max grid--4-col-desktop grid--quarter-max{% endif %}{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider slider--tablet grid--peek{% endif %}{% if section.settings.show_view_all == false or section.settings.collection.products.size < section.settings.products_to_show %} negative-margin{% endif %}{% if section.settings.show_view_all and section.settings.collection.products.size > section.settings.products_to_show %} negative-margin--small{% endif %}" role="list">
-      {%- for product in section.settings.collection.products limit: section.settings.products_to_show -%}
-        <li class="grid__item{% if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 %} slider__slide{% endif %}">
-          {% render 'product-card',
-            product_card_product: product,
-            media_size: section.settings.image_ratio,
-            show_secondary_image: section.settings.show_secondary_image,
-            add_image_padding: section.settings.add_image_padding,
-            show_vendor: section.settings.show_vendor
-          %}
-        </li>
-      {%- else -%}
-        {%- for i in (1..4) -%}
-          <li class="grid__item">
-            {% render 'product-card-placeholder' %}
-          </li>
-        {%- endfor -%}
-      {%- endfor -%}
-    </ul>
-    {%- if section.settings.collection.all_products_count > 2 and section.settings.swipe_on_mobile and section.settings.products_to_show > 2 -%}
-      <div class="slider-buttons no-js-hidden{% if section.settings.collection.all_products_count < 4 %} medium-hide{% endif %}{% if section.settings.collection.all_products_count < 3 %} small-hide{% endif %}">
-        <div class="slider-counter caption">
-          <span class="slider-counter--current">1</span>
-          <span aria-hidden="true"> / </span>
-          <span class="visually-hidden">{{ 'accessibility.of' | t }}</span>
-          <span class="slider-counter--total">{{ products_to_display }}</span>
+    <div>
+      <div class="w-100p h-100p noborder nooutline">
+        <div class="collection page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}">
+          <div class="title-wrapper-with-link title-wrapper-with-link--no-heading title-wrapper--self-padded-tablet-down">
+            <h2 class="title title--no-heading">{{ section.settings.title | escape }}</h2>
+              {%- if section.settings.swipe_on_mobile -%}
+                <a href="{{ section.settings.collection.url }}" class="link underlined-link large-up-hide">{{ 'sections.featured_collection.view_all' | t }}</a>
+              {%- endif -%}
+          </div>
+          {% assign articles = section.blocks | where: 'type', 'image' %}
+          <slider-component class="slider-mobile-gutter">
+            <ul class="grid slider slider--tablet grid--peek negative-margin negative-margin--small" role="list">
+              {%- for article in articles -%}
+                <li class="slider__slide">
+                  <div class="flex column jc-spb ai-c w-90vw w-md-85p mxh-230px mnh-md-230px px-38px px-md-11 py-8 py-md-13 mx-auto ta-c">
+                    <h4 class="ff-heading fs-0 fs-md-4 fs-lg-2 fw-300 lh-130 lh-lg-140 mb-5 mb-md-15px mb-lg-18px">
+                      {{ article.settings.text }}
+                    </h4>
+                    <div class="mxh-30px mxw-80p mnw-50p mt-8 mr-0">
+                      <img 
+                        src="{{ article.settings.image | img_url }}" 
+                        alt="{{ article.settings.image.alt }}" 
+                        class="contain w-100p h-100p"
+                        loading="lazy"
+                      >
+                    </div>
+                  </div>
+                </li>
+              {%- endfor -%}
+            </ul>
+            {%- if articles.size > 1 and section.settings.swipe_on_mobile -%}
+              <div class="slider-buttons no-js-hidden{% if section.settings.collection.all_products_count < 4 %} medium-hide{% endif %}{% if section.settings.collection.all_products_count < 3 %} small-hide{% endif %}">
+                <div class="slider-counter caption">
+                  <span class="slider-counter--current">1</span>
+                  <span aria-hidden="true"> / </span>
+                  <span class="visually-hidden">{{ 'accessibility.of' | t }}</span>
+                  <span class="slider-counter--total">{{ articles.size }}</span>
+                </div>
+                <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
+                <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
+              </div>
+            {%- endif -%}
+          </slider-component>
         </div>
-        <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
-        <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
       </div>
-    {%- endif -%}
-  </slider-component>
-
-  {%- if section.settings.show_view_all and section.settings.collection.all_products_count > section.settings.products_to_show -%}
-    <div class="center{% if section.settings.swipe_on_mobile %} small-hide medium-hide{% endif %}">
-      <a href="{{ section.settings.collection.url }}"
-        class="button"
-        aria-label="{{ 'sections.featured_collection.view_all_label' | t: collection_name: section.settings.collection.title }}"
-      >
-        {{ 'sections.featured_collection.view_all' | t }}
-      </a>
     </div>
-  {%- endif -%}
+  </div>
 </div>
+
 
 {% schema %}
 {
-  "name": "t:sections.featured-collection.name",
+  "name": "Presseslider",
   "tag": "section",
   "class": "spaced-section",
   "settings": [
     {
       "type": "text",
       "id": "title",
-      "default": "Featured collection",
-      "label": "t:sections.featured-collection.settings.title.label"
-    },
-    {
-      "type": "collection",
-      "id": "collection",
-      "label": "t:sections.featured-collection.settings.collection.label"
-    },
-    {
-      "type": "range",
-      "id": "products_to_show",
-      "min": 2,
-      "max": 12,
-      "step": 2,
-      "default": 4,
-      "label": "t:sections.featured-collection.settings.products_to_show.label"
-    },
-    {
-      "type": "checkbox",
-      "id": "show_view_all",
-      "default": true,
-      "label": "t:sections.featured-collection.settings.show_view_all.label"
+      "default": "Die Presse schwebt auf Wolke 7",
+      "label": "Überschrift"
     },
     {
       "type": "checkbox",
       "id": "swipe_on_mobile",
-      "default": false,
-      "label": "t:sections.featured-collection.settings.swipe_on_mobile.label"
-    },
+      "default": true,
+      "label": "Swipen auf Mobilgeräten erlaubt"
+    }
+  ],
+  "blocks": [
     {
-      "type": "header",
-      "content": "t:sections.featured-collection.settings.header.content"
-    },
-    {
-      "type": "select",
-      "id": "image_ratio",
-      "options": [
+      "name": "image",
+      "type": "image",
+      "settings": [
         {
-          "value": "adapt",
-          "label": "t:sections.featured-collection.settings.image_ratio.options__1.label"
+          "type": "image_picker",
+          "id": "image",
+          "label": "Image"
         },
         {
-          "value": "portrait",
-          "label": "t:sections.featured-collection.settings.image_ratio.options__2.label"
-        },
-        {
-          "value": "square",
-          "label": "t:sections.featured-collection.settings.image_ratio.options__3.label"
+          "id": "text",
+          "label": "Pressetext",
+          "type": "text"
         }
-      ],
-      "default": "adapt",
-      "label": "t:sections.featured-collection.settings.image_ratio.label"
-    },
-    {
-      "type": "checkbox",
-      "id": "show_secondary_image",
-      "default": false,
-      "label": "t:sections.featured-collection.settings.show_secondary_image.label"
-    },
-    {
-      "type": "checkbox",
-      "id": "add_image_padding",
-      "default": false,
-      "label": "t:sections.featured-collection.settings.add_image_padding.label"
-    },
-    {
-      "type": "checkbox",
-      "id": "show_vendor",
-      "default": false,
-      "label": "t:sections.featured-collection.settings.show_vendor.label"
+      ]
     }
   ],
   "presets": [
     {
-      "name": "t:sections.featured-collection.presets.name"
+      "name": "Presseslider",
+      "settings": {
+        "title": "Die Presse schwebt auf Wolke 7",
+        "swipe_on_mobile": true
+      },
+      "blocks": [
+        {
+          "type": "image",
+          "settings": {}
+        }
+      ]
     }
   ]
 }

--- a/sections/promise.liquid
+++ b/sections/promise.liquid
@@ -12,6 +12,7 @@
                         src="{{ block.settings.image | img_url: 'x200' }}"
                         alt="{{ block.settings.title }}"
                         height="100"
+                        width="100"
                         loading="lazy"
                         >
                     </div>

--- a/sections/sleepink-footer.liquid
+++ b/sections/sleepink-footer.liquid
@@ -46,7 +46,7 @@
                     {%- if block.type == "image" -%}
                       {%- if block.settings.sections == "payment" -%}
                         <a href="{{ block.settings.url}}">
-                          <img src="{{ block.settings.image | img_url: 'x36' }}" alt="{{ block.settings.image.alt }}" class="inlineblock mr-4 {% if block.settings.largeLogos %}h-30 h-lg-34{% else %}h-18 h-lg-22 my-4{% endif %}">
+                          <img src="{{ block.settings.image | img_url: 'x36' }}" alt="{{ block.settings.image.alt }}" class="inlineblock mr-4 {% if block.settings.largeLogos %}h-30 h-lg-34{% else %}h-18 h-lg-22 my-4{% endif %}" loading="lazy" height="22" width="54">
                         </a>
                       {%- endif -%}
                     {%- endif -%}
@@ -62,7 +62,7 @@
                     {%- if block.type == "image" -%}
                       {%- if block.settings.sections == "shipping" -%}
                         <a href="{{ block.settings.url}}">
-                          <img src="{{ block.settings.image | img_url: 'x36' }}" alt="{{ block.settings.image.alt }}" class="inlineblock mr-4 {% if block.settings.largeLogos %}h-30 h-lg-34{% else %}h-18 h-lg-22 my-4{% endif %}">
+                          <img src="{{ block.settings.image | img_url: 'x36' }}" alt="{{ block.settings.image.alt }}" class="inlineblock mr-4 {% if block.settings.largeLogos %}h-30 h-lg-34{% else %}h-18 h-lg-22 my-4{% endif %}" loading="lazy" height="22" width="156">
                         </a>
                       {%- endif -%}
                     {%- endif -%}
@@ -103,7 +103,7 @@
                     {%- if block.type == "image" -%}
                       {%- if block.settings.sections == "quality" -%}
                         <a href="{{ block.settings.url}}">
-                          <img src="{{ block.settings.image | img_url: 'x36' }}" alt="{{ block.settings.image.alt }}" class="inlineblock mr-4 {% if block.settings.largeLogos %}h-30 h-lg-34{% else %}h-18 h-lg-22 my-4{% endif %}">
+                          <img src="{{ block.settings.image | img_url: 'x36' }}" alt="{{ block.settings.image.alt }}" class="inlineblock mr-4 {% if block.settings.largeLogos %}h-30 h-lg-34{% else %}h-18 h-lg-22 my-4{% endif %}" loading="lazy" height="34" width="34">
                         </a>
                       {%- endif -%}
                     {%- endif -%}
@@ -114,7 +114,7 @@
           </div>
         </div>
         <div class="h-0 bdw-1px bds-solid op-012 w-100p desktop">&nbsp;</div>
-        <img src="{{ section.settings.corporate_logo | img_url: 'x80' }}" alt="{{ section.settings.corporate_logo.alt }}" class="h-39 h-lg-57 mt-lg-10 mb-lg-3 contain">
+        <img src="{{ section.settings.corporate_logo | img_url: 'x80' }}" alt="{{ section.settings.corporate_logo.alt }}" class="h-39 h-lg-57 mt-lg-10 mb-lg-3 contain" loading="lazy" height="57" width="260" >
         <div class="ff-heading ta-c fs-3 fs-lg-6 mx-2">{{ section.settings.corporate_slogan }}</div>
       </div>
     </div>


### PR DESCRIPTION
## Implementierung des Pressesliders

- Verwendung eines modifizierten Collection-Sliders
- getrennte Slider für Mobile und Tablet/Desktop
- Slider auch für Desktop (Unterschied zu der Built-in-Version)
- Um Konfusionen zu vermeiden, sind eigene Klassen hier mit dem Präfix "ps-" (für Presseslider) versehen, bis Klassen einmalig in custom.css verlagert worden sind.