### PR TITLE
enhance Presselogo section for RetailerLogos

### DIFF
--- a/assets/presse-logos.css
+++ b/assets/presse-logos.css
@@ -124,9 +124,16 @@ p {
   letter-spacing: -1.24px;
 }
 
-.h-18 {
+.h-18px {
   height: 18px;
-  overflow: hidden;
+}
+
+.h-41px {
+  height: 41px;
+}
+
+.w-auto {
+  width: auto;
 }
 
 @media screen and (min-width: 500px) {

--- a/assets/presse-logos.css
+++ b/assets/presse-logos.css
@@ -26,6 +26,10 @@ p {
   grid-column: 2 / span 3;
 }
 
+.SectionGrid-Narrow {
+  grid-column: 3 / span 1;
+}
+
 .flex {
   display: flex;
 }
@@ -56,6 +60,10 @@ p {
 
 .mb-7 {
   margin-bottom: 24px;
+}
+
+.mb-8 {
+  margin-bottom: 32px;
 }
 
 .py-4 {
@@ -96,12 +104,24 @@ p {
   font-size: 22px;
 }
 
+.fs-38px {
+  font-size: 38px;
+}
+
 .lh-100 {
   line-height: 100%;
 }
 
 .lh-136 {
   line-height: 136%;
+}
+
+.lh-44px {
+  line-height: 44px;
+}
+
+.ls-m124 {
+  letter-spacing: -1.24px;
 }
 
 .h-18 {

--- a/sections/presse-logos.liquid
+++ b/sections/presse-logos.liquid
@@ -2,7 +2,7 @@
 
 <div class="py-7 py-md-9 color-{{ section.settings.color_scheme }}">
   <div class="SectionGrid ndesktop pt-0 pt-md-7 pb-0 pb-md-10">
-    <div class="anthracite flex row jc-spa ai-c">
+    <div class="flex row jc-spa ai-c">
       <p class="ff-heading fw-500 fs-1 fs-md-4 lh-136 mb-7">
         {{ section.settings.introText }}
       </p>
@@ -23,10 +23,19 @@
     </div>
   </div>
   <div class="SectionGrid desktopgrid">
+    {% if section.settings.positionIntro == "top" %}
+      <div class="SectionGrid-Narrow mb-8">
+        <p class="mx-auto ta-c ff-heading fs-38px lh-44px ls-m124">
+          {{ section.settings.introText | escape }}
+        </p>
+      </div>
+    {% endif %}
     <div class="SectionGrid-Wide flex row jc-spa ai-c py-4 h-70 wrap">
-      <p class="ff-heading fw-400 fs-4 lh-100">
-        {{ section.settings.introText }}
-      </p> 
+      {% if section.settings.positionIntro == "left" %}
+        <p class="ff-heading fw-400 fs-4 lh-100">
+          {{ section.settings.introText | escape }}
+        </p> 
+      {% endif %}
       {% for block in section.blocks %}
         {% assign bSettings = block.settings %}
         {% if bSettings.showDesktop %}
@@ -53,6 +62,22 @@
       "type": "text",
       "id": "introText",
       "label": "Presselogos"
+    },
+    {
+      "type": "select",
+      "id": "positionIntro",
+      "label": "Position des einleitenden Textes (Desktop)",
+      "default": "top",
+      "options": [
+        {
+          "value": "top",
+          "label": "über den Logos"
+        },
+        {
+          "value": "left",
+          "label": "links neben den Logos"
+        }
+      ]
     },
     {
       "type": "select",

--- a/sections/presse-logos.liquid
+++ b/sections/presse-logos.liquid
@@ -16,7 +16,8 @@
           alt="{{ bSettings.image.alt | escape }}" 
           loading="lazy" 
           height="18"
-          width="90" 
+          width="90"
+          class="h-18px w-auto"
         />
         {% endif %}
       {% endfor %}
@@ -45,6 +46,7 @@
           loading="lazy" 
           height="41" 
           width="205"
+          class="h-41px w-auto"
         />
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
# RetailerLogo-Section

Hierzu wurde die Presselogo-Section erweitert, so dass der einleitende Text wahlweise links neben den Logos oder über den Logos stehen kann.