### PR TITLE
center logo

### DIFF
--- a/assets/sleepink-footer.css
+++ b/assets/sleepink-footer.css
@@ -152,6 +152,11 @@ a:hover {
   margin-right: 12px;
 }
 
+.mx-auto {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .mx-2 {
   margin-left: 4px;
   margin-right: 4px;

--- a/sections/sleepink-footer.liquid
+++ b/sections/sleepink-footer.liquid
@@ -114,7 +114,7 @@
           </div>
         </div>
         <div class="h-0 bdw-1px bds-solid op-012 w-100p desktop">&nbsp;</div>
-        <img src="{{ section.settings.corporate_logo | img_url: 'x80' }}" alt="{{ section.settings.corporate_logo.alt }}" class="h-39 h-lg-57 mt-lg-10 mb-lg-3 contain" loading="lazy" height="57" width="260" >
+        <img src="{{ section.settings.corporate_logo | img_url: 'x80' }}" alt="{{ section.settings.corporate_logo.alt }}" class="h-39 h-lg-57 mt-lg-10 mb-lg-3 mx-auto contain" loading="lazy" height="57" width="260" >
         <div class="ff-heading ta-c fs-3 fs-lg-6 mx-2">{{ section.settings.corporate_slogan }}</div>
       </div>
     </div>


### PR DESCRIPTION
Das Footer-Logo war falsch positioniert. Mit diesem PR wird es zentriert, so dass es wieder über dem Logo liegt.