### PR TITLE
Hotfix/sticky header

### DIFF
--- a/assets/sleepink-header.css
+++ b/assets/sleepink-header.css
@@ -54,6 +54,10 @@ details[open].menu-opening > .menu-drawer__submenu {
   height: unset !important;
 }
 
+#shopify-section-header.animate {
+  transition: transform 0.45s ease-out !important;
+}
+
 /* eigene Stile */
 
 details.menu-drawer-container summary span svg:first-child {

--- a/assets/sleepink-header.css
+++ b/assets/sleepink-header.css
@@ -231,7 +231,7 @@ a:hover {
 }
 
 .shadow {
-  box-shadow: 0px 2px 24px #00000017;
+  box-shadow: 0px 2px 0px #00000017;
 }
 
 .shadow-mobmenu {

--- a/assets/sleepink-header.css
+++ b/assets/sleepink-header.css
@@ -160,6 +160,10 @@ a:hover {
   padding: 2rem;
 }
 
+.pt-0 {
+  padding-top: 0;
+}
+
 .px-6 {
   padding-left: 2rem;
   padding-right: 2rem;

--- a/assets/sleepink-header.css
+++ b/assets/sleepink-header.css
@@ -54,8 +54,8 @@ details[open].menu-opening > .menu-drawer__submenu {
   height: unset !important;
 }
 
-#shopify-section-header.animate {
-  transition: transform 0.45s ease-out !important;
+#shopify-section-sleepink-header.animate {
+  transition: transform 0.45s ease-in-out !important;
 }
 
 /* eigene Stile */

--- a/sections/sleepink-header.liquid
+++ b/sections/sleepink-header.liquid
@@ -231,7 +231,7 @@
     }
 
     connectedCallback() {
-      this.header = document.getElementById('shopify-section-header');
+      this.header = document.getElementById('shopify-section-sleepink-header');
       this.headerBounds = {};
       this.currentScrollTop = 0;
 
@@ -344,7 +344,7 @@
 {% schema %}
 {
   "name": "t:sections.header.name",
-  "class": "z-10000 pos-rel",
+  "class": "z-10000",
   "settings": [
     {
       "type": "select",

--- a/sections/sleepink-header.liquid
+++ b/sections/sleepink-header.liquid
@@ -30,7 +30,7 @@
 %}
 
 <{% if section.settings.enable_sticky_header %}sticky-sleepink-header{% else %}div{% endif %} class="header-wrapper{% if section.settings.show_line_separator %} header-wrapper--border-bottom{% endif %} SectionGrid shadow sticky color-{{ section.settings.color_scheme }}">
-  <header class="SectionGrid-Wide header header--has-menu flex row jc-spb ai-c px-6 h-80 z-100 shadow sticky z-10000 color-{{ section.settings.color_scheme }}" id="shopify-section-header">
+  <header class="SectionGrid-Wide header header--has-menu flex row jc-spb ai-c px-6 pt-0 h-80 z-100 shadow sticky z-10000 color-{{ section.settings.color_scheme }}" id="shopify-section-header">
     {% comment  %} Hamburger-Menü {% endcomment %}
     <header-drawer data-breakpoint="tablet" class="color-{{ section.settings.color_scheme }} ndesktop">
       <details class="menu-drawer-container color-{{ section.settings.color_scheme }}">

--- a/sections/sleepink-header.liquid
+++ b/sections/sleepink-header.liquid
@@ -29,7 +29,7 @@
   endcase
 %}
 
-<{% if section.settings.enable_sticky_header %}sticky-header{% else %}div{% endif %} class="header-wrapper{% if section.settings.show_line_separator %} header-wrapper--border-bottom{% endif %} SectionGrid shadow sticky color-{{ section.settings.color_scheme }}">
+<{% if section.settings.enable_sticky_header %}sticky-sleepink-header{% else %}div{% endif %} class="header-wrapper{% if section.settings.show_line_separator %} header-wrapper--border-bottom{% endif %} SectionGrid shadow sticky color-{{ section.settings.color_scheme }}">
   <header class="SectionGrid-Wide header header--has-menu flex row jc-spb ai-c px-6 h-80 z-100 shadow sticky z-10000 color-{{ section.settings.color_scheme }}" id="shopify-section-header">
     {% comment  %} Hamburger-Menü {% endcomment %}
     <header-drawer data-breakpoint="tablet" class="color-{{ section.settings.color_scheme }} ndesktop">
@@ -212,7 +212,7 @@
       </a>
     </div>
   </header>
-</{% if section.settings.enable_sticky_header %}sticky-header{% else %}div{% endif %}>
+</{% if section.settings.enable_sticky_header %}sticky-sleepink-header{% else %}div{% endif %}>
 
 <svg xmlns="http://www.w3.org/2000/svg" class="hidden">
   <symbol id="icon-search" viewbox="0 0 18 19" fill="none">
@@ -225,7 +225,7 @@
 </svg>
 
 {% javascript %}
-  class StickyHeader extends HTMLElement {
+  class StickySleepinkHeader extends HTMLElement {
     constructor() {
       super();
     }
@@ -295,7 +295,7 @@
     }
   }
 
-  customElements.define('sticky-header', StickyHeader);
+  customElements.define('sticky-sleepink-header', StickySleepinkHeader);
 {% endjavascript %}
 
 


### PR DESCRIPTION
# Beheben des Sticky-Verhaltens beim Menü

## Behobene Fehler

1. ID im Javascript-Code auf das richtige Element gesetzt (Wrapper statt beschrifteter Teil des Menüs)
2. Animation verlängert (0.45s statt 0.15s)
3. Elemente umbenannt (zur Vermeidung von Konflikten mit anderen Elementen)