### PR TITLE
Feature/iframe

### DIFF
--- a/assets/iframe.css
+++ b/assets/iframe.css
@@ -1,0 +1,36 @@
+.if-SectionGrid {
+  display: block;
+  grid-template-columns:
+    1fr minmax(25px, 200px) minmax(600px, 900px) minmax(25px, 200px)
+    1fr;
+}
+
+.if-SectionGrid-Full {
+  grid-column: 1 / span 5;
+}
+
+.if-SectionGrid-Wide {
+  grid-column: 2 / span 3;
+}
+
+.if-SectionGrid-Narrow {
+  grid-column: 3 / span 1;
+}
+
+.if-w-100p {
+  width: 100%;
+}
+
+.if-h-100p {
+  height: 100%;
+}
+
+.if-noborder {
+  border: none;
+}
+
+@media screen and (min-width: 990px) {
+  .if-SectionGrid {
+    display: grid;
+  }
+}

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -122,8 +122,6 @@
       {{ content_for_layout }}
     </main>
 
-    {% section 'iframe' %}
-
     {% section 'sleepink-footer' %}
 
     <ul hidden>

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -122,6 +122,8 @@
       {{ content_for_layout }}
     </main>
 
+    {% section 'iframe' %}
+
     {% section 'sleepink-footer' %}
 
     <ul hidden>

--- a/sections/iframe.liquid
+++ b/sections/iframe.liquid
@@ -1,0 +1,87 @@
+{% liquid 
+  case section.settings.width
+    when 'full'
+      assign width = 'if-SectionGrid-Full'
+    when 'wide'
+      assign width = 'if-SectionGrid-Wide'
+    when 'narrow'
+      assign width = 'if-SectionGrid-Narrow'
+    else
+      assign width = 'if-SectionGrid-Wide'
+    endcase
+%}
+
+<div class="if-SectionGrid">
+  <div class="{{ width }} w-100p h-100p">
+    <iframe title="{{ section.settings.title | escape }}" src="{{ section.settings.url }}" scrolling="no" class="w-100p noborder" id="iframe"></iframe>
+  </div>
+</div>
+
+<script>
+const findHeight = e => {
+  const heights = [];
+  if (e.data.hasOwnProperty("frameHeight")) {
+    heights.push(e.data["frameHeight"]);
+  }
+  if (e.data.hasOwnProperty("offset")) {
+    heights.push(e.data["offset"]);
+  }
+  if (e.data.hasOwnProperty("scroll")) {
+    heights.push(e.data["scroll"]);
+  }
+  if (heights.length > 0) {
+    const maxHeight = Math.max(...heights);
+    const height = `${maxHeight + 30}px`;
+    document.getElementById("iframe").height = height;
+  }
+}
+window.addEventListener("message", findHeight);
+</script>
+
+{% schema %}
+{
+  "name": "Iframe",
+  "tag": "section",
+  "class": "section",
+  "settings": [
+    {
+      "type": "text",
+      "id": "title",
+      "label": "Überschrift"
+    },
+    {
+      "type": "url",
+      "id": "url",
+      "label": "Adresse der darzustellenden Seite"
+    },
+    {
+      "type": "select",
+      "id": "width",
+      "label": "Breite des Elements",
+      "options": [
+        {
+          "value": "full",
+          "label": "volle Seitenbreite"
+        },
+        {
+          "value": "wide",
+          "label": "breites Layout (max. 1300px)"
+        },
+        {
+          "value": "narrow",
+          "label": "schmales Layout (max. 900px)"
+        }
+      ],
+      "default": "wide"
+    }
+  ],
+  "presets": [
+    {
+    "name": "Iframe",
+    "settings": {
+      "width": "wide"
+    }
+  }
+]
+}
+{% endschema %}

--- a/sections/iframe.liquid
+++ b/sections/iframe.liquid
@@ -1,3 +1,5 @@
+{{ 'iframe.css' | asset_url | stylesheet_tag }}
+
 {% liquid 
   case section.settings.width
     when 'full'
@@ -12,8 +14,8 @@
 %}
 
 <div class="if-SectionGrid">
-  <div class="{{ width }} w-100p h-100p">
-    <iframe title="{{ section.settings.title | escape }}" src="{{ section.settings.url }}" scrolling="no" class="w-100p noborder" id="iframe"></iframe>
+  <div class="{{ width }} if-w-100p if-h-100p">
+    <iframe title="{{ section.settings.title | escape }}" src="{{ section.settings.url }}" scrolling="no" class="if-w-100p if-noborder" id="iframe"></iframe>
   </div>
 </div>
 


### PR DESCRIPTION
# Implementierung der Iframe-Section für den Storefinder

**Wichtig**: Die Seite, die in dem Iframe geladen wird, muss ihre Höhe mitteilen. Das geht über den folgenden Code auf der Seite im Iframe:
```javascript
function sendPostMessage(){
  const element = document.getElementsByTagName("main")[0];
    window.parent.postMessage({
      scrollHeight: element.scrollHeight,
      offsetHeight: element.offsetHeight
    }, "*");
}
window.onload = sendPostMessage;
window.onresize = sendPostMessage;
```
Der Selektor (`const element`) muss ggf. angepasst werden.