### PR TITLE
hotfix/decorative-images

### DIFF
--- a/assets/component-123.css
+++ b/assets/component-123.css
@@ -112,12 +112,23 @@
   z-index: 2;
   justify-self: right;
 }
+
+.decoration-left img {
+  object-fit: contain;
+  object-position: left center;
+}
+
 .decoration-right {
   height: 400px;
   grid-column: 5 / span 3;
   grid-row: 1 / span 1;
   display: none;
   z-index: -1;
+}
+
+.decoration-right img {
+  object-fit: contain;
+  object-position: right center;
 }
 
 @media screen and (min-width: 500px) {


### PR DESCRIPTION
# Richtiges Aussehen der Deko-Bilder

- `object-fit` auf `contain` gesetzt
- `object-position` für das linke Bild auf `left center` gesetzt
- `object-position` für das rechte Bild auf `right center` gesetzt