### PR TITLE
Hotfix/presseslider

### DIFF
--- a/assets/custom.js
+++ b/assets/custom.js
@@ -46,6 +46,79 @@ class SleepinkSlider extends HTMLElement {
 
     this.pageCount.textContent = this.currentPage
     this.pageTotal.textContent = this.totalPages
+  }
+
+  onButtonClick(event) {
+    event.preventDefault()
+    this.currentPage =
+      Math.round(this.slider.scrollLeft / this.sliderItems[0].clientWidth) + 1
+    this.totalPages = this.sliderItems.length - this.slidesPerPage + 1
+    const slideScrollPosition =
+      event.currentTarget.name === "next"
+        ? this.currentPage === this.totalPages
+          ? this.slider.scrollLeft -
+            (this.totalPages - 1) * this.sliderItems[0].clientWidth
+          : this.slider.scrollLeft + this.sliderItems[0].clientWidth
+        : this.currentPage === 1
+        ? this.slider.scrollLeft +
+          (this.totalPages - 1) * this.sliderItems[0].clientWidth
+        : this.slider.scrollLeft - this.sliderItems[0].clientWidth
+    this.slider.scrollTo({
+      left: slideScrollPosition,
+    })
+  }
+}
+
+customElements.define("sleepink-slider", SleepinkSlider)
+
+class PressSlider extends HTMLElement {
+  constructor() {
+    super()
+    this.slider = this.querySelector("ul")
+    this.sliderItems = this.querySelectorAll("li")
+    this.pageCount = this.querySelector(".slider-counter--current")
+    this.pageTotal = this.querySelector(".slider-counter--total")
+    this.prevButton = this.querySelector('button[name="previous"]')
+    this.nextButton = this.querySelector('button[name="next"]')
+
+    if (!this.slider || !this.nextButton) return
+
+    const resizeObserver = new ResizeObserver((entries) => this.initPages())
+    resizeObserver.observe(this.slider)
+
+    this.slider.addEventListener("scroll", this.update.bind(this))
+    this.prevButton.addEventListener("click", this.onButtonClick.bind(this))
+    this.nextButton.addEventListener("click", this.onButtonClick.bind(this))
+  }
+
+  initPages() {
+    if (!this.sliderItems.length === 0) return
+    this.slidesPerPage = Math.floor(
+      this.slider.clientWidth / this.sliderItems[0].clientWidth
+    )
+    this.totalPages = this.sliderItems.length - this.slidesPerPage + 1
+    this.update()
+  }
+
+  update() {
+    if (!this.pageCount || !this.pageTotal) return
+    this.currentPage =
+      Math.round(this.slider.scrollLeft / this.sliderItems[0].clientWidth) + 1
+
+    // if (this.currentPage === 1) {
+    //   this.prevButton.setAttribute("disabled", true)
+    // } else {
+    this.prevButton.removeAttribute("disabled")
+    // }
+
+    // if (this.currentPage === this.totalPages) {
+    //   this.nextButton.setAttribute("disabled", true)
+    // } else {
+    this.nextButton.removeAttribute("disabled")
+    // }
+
+    this.pageCount.textContent = this.currentPage
+    this.pageTotal.textContent = this.totalPages
     const previousSlide =
       Number(this.pageCount.textContent) > 1
         ? this.sliderItems[Number(this.pageCount.textContent) - 2]
@@ -81,7 +154,7 @@ class SleepinkSlider extends HTMLElement {
   }
 }
 
-customElements.define("sleepink-slider", SleepinkSlider)
+customElements.define("press-slider", PressSlider)
 
 class AnimatedSlider extends HTMLElement {
   constructor() {

--- a/assets/custom.js
+++ b/assets/custom.js
@@ -46,6 +46,18 @@ class SleepinkSlider extends HTMLElement {
 
     this.pageCount.textContent = this.currentPage
     this.pageTotal.textContent = this.totalPages
+    const previousSlide =
+      Number(this.pageCount.textContent) > 1
+        ? this.sliderItems[Number(this.pageCount.textContent) - 2]
+        : this.sliderItems[this.totalPages - 1]
+    const prevSlideCont = document.getElementById("prevSlide")
+    prevSlideCont.innerHTML = previousSlide.childNodes[1].innerHTML
+    const nextSlide =
+      Number(this.pageCount.textContent) === this.sliderItems.length
+        ? this.sliderItems[0]
+        : this.sliderItems[Number(this.pageCount.textContent)]
+    const nextSlideCont = document.getElementById("nextSlide")
+    nextSlideCont.innerHTML = nextSlide.childNodes[1].innerHTML
   }
 
   onButtonClick(event) {

--- a/assets/presseslider.css
+++ b/assets/presseslider.css
@@ -278,7 +278,7 @@ sleepink-slider::after {
     line-height: 44px;
   }
   .ps-fs-lg-2 {
-    font-size: 16px;
+    font-size: 18px;
   }
   .ps-fs-lg-38px {
     font-size: 38px;

--- a/assets/presseslider.css
+++ b/assets/presseslider.css
@@ -286,6 +286,9 @@ sleepink-slider::after {
   .ps-lh-lg-140 {
     line-height: 140%;
   }
+  .ps-lh-lg-44px {
+    line-height: 44px;
+  }
   .ps-fw-lg-400 {
     font-weight: 400;
   }

--- a/assets/presseslider.css
+++ b/assets/presseslider.css
@@ -69,6 +69,10 @@ sleepink-slider::after {
   display: none;
 }
 
+.ps-desktop {
+  display: none;
+}
+
 .ps-SectionGrid {
   display: block;
   grid-template-columns:
@@ -292,6 +296,9 @@ sleepink-slider::after {
 }
 
 @media screen and (min-width: 990px) {
+  .ps-desktop {
+    display: block;
+  }
   .ps-SectionGrid {
     display: grid;
   }

--- a/assets/presseslider.css
+++ b/assets/presseslider.css
@@ -280,6 +280,9 @@ sleepink-slider::after {
   .ps-fs-lg-2 {
     font-size: 16px;
   }
+  .ps-fs-lg-38px {
+    font-size: 38px;
+  }
   .ps-lh-lg-140 {
     line-height: 140%;
   }

--- a/assets/presseslider.css
+++ b/assets/presseslider.css
@@ -36,6 +36,29 @@ sleepink-slider::after {
   clear: both;
 }
 
+#prevSlide h4,
+#nextSlide h4 {
+  font-size: 12px !important;
+  opacity: 0.6 !important;
+  margin-top: 116px;
+  text-align: center;
+}
+
+#prevSlide > div,
+#nextSlide > div {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+#prevSlide img,
+#nextSlide img {
+  height: 20px;
+  width: auto;
+  opacity: 0.6 !important;
+}
+
 /* Own styles, prefixed with ps- */
 
 .ps-mobile {
@@ -51,6 +74,7 @@ sleepink-slider::after {
   grid-template-columns:
     1fr minmax(25px, 200px) minmax(700px, 900px) minmax(25px, 200px)
     1fr;
+  grid-template-rows: 1fr;
 }
 
 .ps-SectionGrid-Narrow {
@@ -71,6 +95,18 @@ sleepink-slider::after {
 
 .ps-ai-c {
   align-items: center;
+}
+
+.ps-col-1-2 {
+  grid-column: 1 / span 2;
+}
+
+.ps-col-4-5 {
+  grid-column: 4 / span 2;
+}
+
+.ps-row-1 {
+  grid-row: 1 / span 1;
 }
 
 .ps-w-100p {

--- a/assets/presseslider.css
+++ b/assets/presseslider.css
@@ -69,6 +69,10 @@ sleepink-slider::after {
   display: none;
 }
 
+.ps-nmobileflex {
+  display: none;
+}
+
 .ps-desktop {
   display: none;
 }
@@ -95,6 +99,10 @@ sleepink-slider::after {
 
 .ps-jc-spb {
   justify-content: space-between;
+}
+
+.ps-jc-c {
+  justify-content: center;
 }
 
 .ps-ai-c {
@@ -253,12 +261,42 @@ sleepink-slider::after {
   outline: none;
 }
 
+.slider-buttons {
+  justify-content: space-between !important;
+}
+
+.slider-buttons div {
+  visibility: hidden;
+}
+
+.press-button {
+  cursor: pointer;
+  background-color: #ffffff;
+  border: none;
+  width: 55px;
+  height: 55px;
+  padding: 12px;
+  border-radius: 50%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  box-shadow: rgba(27, 45, 69, 0.1) 0px 5px 10px 0px;
+  margin-left: 0;
+  position: relative;
+  bottom: 150px;
+}
+
 @media screen and (min-width: 500px) {
   .ps-mobile {
     display: none;
   }
   .ps-nmobile {
     display: block;
+  }
+  .ps-nmobileflex {
+    display: flex;
   }
   .ps-w-md-85p {
     width: 85%;

--- a/sections/presseslider.liquid
+++ b/sections/presseslider.liquid
@@ -3,7 +3,7 @@
 
 <noscript>{{ 'component-slider.css' | asset_url | stylesheet_tag }}</noscript>
 
-<div class="ps-SectionGrid ps-ofl-hidden ps-pos-rel ps-w-100p ps-bgcol-bg ps-px-2p ps-px-md-3p ps-pt-9 ps-pt-md-7 ps-pt-lg-10 ps-pb-11 ps-pb-md-12 ps-pb-lg-10 color-{{ section.settings.color_scheme }}">
+<div class="ps-SectionGrid ps-ofl-hidden ps-pos-rel ps-w-100p ps-bgcol-bg ps-pt-9 ps-pt-md-7 ps-pt-lg-10 ps-pb-11 ps-pb-md-12 ps-pb-lg-10 color-{{ section.settings.color_scheme }}">
   <div class="ps-SectionGrid-Narrow ps-bgcol-bg">
     <h3 class="ps-ff-heading ps-col-fg ps-fs-7 ps-fs-lg-38px ps-lh-30px ps-lh-lg-44px ps-ls-m124 ps-fw-500 ps-fw-lg-400 ps-mx-auto ps-mb-8 ps-pt-0 ps-ta-c ps-w-84p ps-w-md-74p ps-w-lg-auto">{{ section.settings.title }}</h3>
     <div>
@@ -93,100 +93,8 @@
       {% comment %} End of Tablet and Desktop Slider {% endcomment %}
     </div>
   </div>
-</div>
-
-<div class="ps-SectionGrid ps-ofl-hidden ps-pos-rel ps-w-100p ps-bgcol-bg ps-pt-9 ps-pt-md-7 ps-pt-lg-10 ps-pb-11 ps-pb-md-12 ps-pb-lg-10 color-{{ section.settings.color_scheme }}">
-  <div class="ps-SectionGrid-Narrow ps-bgcol-bg">
-    <h3 class="ps-ff-heading ps-col-fg ps-fs-7 ps-fs-lg-38px ps-lh-30px ps-lh-lg-44px ps-ls-m124 ps-fw-500 ps-fw-lg-400 ps-mx-auto ps-mb-8 ps-pt-0 ps-ta-c ps-w-84p ps-w-md-74p ps-w-lg-auto">{{ section.settings.title }}</h3>
-    <div>
-      {% comment %} Mobile Slider {% endcomment %}
-      {% comment %} <div class="ps-w-100p ps-h-100p ps-noborder ps-nooutline ps-mobile">
-        <div class="collection page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}">
-          {% assign articles = section.blocks | where: 'type', 'image' %}
-          <sleepink-slider class="slider-mobile-gutter">
-            <ul class="grid slider slider--tablet grid--peek negative-margin negative-margin--small" role="list">
-              {%- for article in articles -%}
-                <li class="slider__slide w-100p">
-                  <div class="ps-flex ps-column ps-jc-spb ps-ai-c ps-w-90vw ps-w-md-85p ps-mxh-230px ps-mnh-md-230px ps-px-38px ps-px-md-11 ps-py-8 ps-py-md-13 ps-mx-auto ps-ta-c">
-                    <h4 class="ps-ff-heading ps-fs-0 ps-fs-md-4 ps-fs-lg-2 ps-fw-300 ps-lh-130 ps-lh-lg-140 ps-mb-5 ps-mb-md-15px ps-mb-lg-18px ps-col-fg">
-                      {{ article.settings.text }}
-                    </h4>
-                    <div class="ps-mxh-30px ps-mxw-80p ps-mnw-50p ps-mt-8 ps-mr-0">
-                      <img 
-                        src="{{ article.settings.image | img_url: 'x30' }}" 
-                        alt="{{ article.settings.image.alt }}" 
-                        width="150"
-                        height="30"
-                        class="ps-contain ps-w-100p ps-h-100p"
-                        loading="lazy"
-                      >
-                    </div>
-                  </div>
-                </li>
-              {%- endfor -%}
-            </ul>
-            {%- if articles.size > 1 and section.settings.swipe_on_mobile -%}
-              <div class="slider-buttons no-js-hidden">
-                <div class="slider-counter caption">
-                  <span class="slider-counter--current">1</span>
-                  <span aria-hidden="true"> / </span>
-                  <span class="visually-hidden">{{ 'accessibility.of' | t }}</span>
-                  <span class="slider-counter--total">{{ articles.size }}</span>
-                </div>
-                <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
-                <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
-              </div>
-            {%- endif -%}
-          </sleepink-slider>
-        </div>
-      </div> {% endcomment %}
-      {% comment %} End of Mobile Slider {% endcomment %}
-      {% comment %} Tablet and Desktop Slider {% endcomment %}
-      <div class="ps-nmobile ps-w-100p ps-h-100p ps-noborder ps-nooutline">
-        <div class="collection page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}">
-          {% assign articles = section.blocks | where: 'type', 'image' %}
-          <sleepink-slider class="slider-mobile-gutter" id="pressslider-desktop">
-            <ul class="grid slider slider--desktop slider--tablet grid--peek negative-margin negative-margin--small" role="list">
-              {%- for article in articles -%}
-                <li class="slider__slide w-100p">
-                  <div class="ps-flex ps-column ps-jc-spb ps-ai-c ps-w-90vw ps-w-md-85p ps-mxh-230px ps-mnh-md-230px ps-px-38px ps-px-md-11 ps-py-8 ps-py-md-13 ps-mx-auto ps-ta-c">
-                    <h4 class="ps-ff-heading ps-fs-0 ps-fs-md-4 ps-fs-lg-2 ps-fw-300 ps-lh-130 ps-lh-lg-140 ps-mb-5 ps-mb-md-15px ps-mb-lg-18px">
-                      {{ article.settings.text }}
-                    </h4>
-                    <div class="ps-mxh-30px ps-mxw-80p ps-mnw-50p ps-mt-8 ps-mr-0">
-                      <img 
-                        src="{{ article.settings.image | img_url: 'x30' }}" 
-                        alt="{{ article.settings.image.alt }}" 
-                        class="ps-contain ps-w-100p ps-h-100p"
-                        width="150"
-                        height="30"
-                        loading="lazy"
-                      >
-                    </div>
-                  </div>
-                </li>
-              {%- endfor -%}
-            </ul>
-            {%- if articles.size > 1 and section.settings.swipe_on_mobile -%}
-              <div class="slider-buttons no-js-hidden">
-                <div class="slider-counter caption">
-                  <span class="slider-counter--current">1</span>
-                  <span aria-hidden="true"> / </span>
-                  <span class="visually-hidden">{{ 'accessibility.of' | t }}</span>
-                  <span class="slider-counter--total">{{ articles.size }}</span>
-                </div>
-                <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
-                <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
-              </div>
-            {%- endif -%}
-          </sleepink-slider>
-        </div>
-      </div>
-      {% comment %} End of Tablet and Desktop Slider {% endcomment %}
-    </div>
-  </div>
-  <div id="prevSlide" class="ps-col-1-2 ps-row-1 ps-mxh-230px ps-ofl-hidden">&nbsp;</div>
-  <div id="nextSlide" class="ps-col-4-5 ps-row-1 ps-mxh-230px ps-ofl-hidden">&nbsp;</div>
+  <div id="prevSlide" class="ps-desktop ps-col-1-2 ps-row-1 ps-mxh-230px ps-ofl-hidden">&nbsp;</div>
+  <div id="nextSlide" class="ps-desktop ps-col-4-5 ps-row-1 ps-mxh-230px ps-ofl-hidden">&nbsp;</div>
 </div>
 
 

--- a/sections/presseslider.liquid
+++ b/sections/presseslider.liquid
@@ -11,7 +11,7 @@
       <div class="ps-w-100p ps-h-100p ps-noborder ps-nooutline ps-mobile">
         <div class="collection page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}">
           {% assign articles = section.blocks | where: 'type', 'image' %}
-          <sleepink-slider class="slider-mobile-gutter">
+          <press-slider class="slider-mobile-gutter">
             <ul class="grid slider slider--tablet grid--peek negative-margin negative-margin--small" role="list">
               {%- for article in articles -%}
                 <li class="slider__slide w-100p">
@@ -35,17 +35,17 @@
             </ul>
             {%- if articles.size > 1 and section.settings.swipe_on_mobile -%}
               <div class="slider-buttons no-js-hidden">
+                <button type="button" class="slider-button slider-button--prev press-button" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
                 <div class="slider-counter caption">
                   <span class="slider-counter--current">1</span>
                   <span aria-hidden="true"> / </span>
                   <span class="visually-hidden">{{ 'accessibility.of' | t }}</span>
                   <span class="slider-counter--total">{{ articles.size }}</span>
                 </div>
-                <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
-                <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
+                <button type="button" class="slider-button slider-button--next press-button" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
               </div>
             {%- endif -%}
-          </sleepink-slider>
+          </press-slider>
         </div>
       </div>
       {% comment %} End of Mobile Slider {% endcomment %}
@@ -53,7 +53,7 @@
       <div class="ps-nmobile ps-w-100p ps-h-100p ps-noborder ps-nooutline">
         <div class="collection page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}">
           {% assign articles = section.blocks | where: 'type', 'image' %}
-          <sleepink-slider class="slider-mobile-gutter" id="pressslider-desktop">
+          <press-slider class="slider-mobile-gutter" id="pressslider-desktop">
             <ul class="grid slider slider--desktop slider--tablet grid--peek negative-margin negative-margin--small" role="list">
               {%- for article in articles -%}
                 <li class="slider__slide w-100p">
@@ -77,17 +77,17 @@
             </ul>
             {%- if articles.size > 1 and section.settings.swipe_on_mobile -%}
               <div class="slider-buttons no-js-hidden">
+                <button type="button" class="slider-button slider-button--prev press-button" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
                 <div class="slider-counter caption">
                   <span class="slider-counter--current">1</span>
                   <span aria-hidden="true"> / </span>
                   <span class="visually-hidden">{{ 'accessibility.of' | t }}</span>
                   <span class="slider-counter--total">{{ articles.size }}</span>
                 </div>
-                <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
-                <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
+                <button type="button" class="slider-button slider-button--next press-button" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
               </div>
             {%- endif -%}
-          </sleepink-slider>
+          </press-slider>
         </div>
       </div>
       {% comment %} End of Tablet and Desktop Slider {% endcomment %}

--- a/sections/presseslider.liquid
+++ b/sections/presseslider.liquid
@@ -56,7 +56,7 @@
           <sleepink-slider class="slider-mobile-gutter">
             <ul class="grid slider slider--desktop slider--tablet grid--peek negative-margin negative-margin--small" role="list">
               {%- for article in articles -%}
-                <li class="slider__slide ps-mxw-100p">
+                <li class="slider__slide w-100p">
                   <div class="ps-flex ps-column ps-jc-spb ps-ai-c ps-w-90vw ps-w-md-85p ps-mxh-230px ps-mnh-md-230px ps-px-38px ps-px-md-11 ps-py-8 ps-py-md-13 ps-mx-auto ps-ta-c">
                     <h4 class="ps-ff-heading ps-fs-0 ps-fs-md-4 ps-fs-lg-2 ps-fw-300 ps-lh-130 ps-lh-lg-140 ps-mb-5 ps-mb-md-15px ps-mb-lg-18px">
                       {{ article.settings.text }}

--- a/sections/presseslider.liquid
+++ b/sections/presseslider.liquid
@@ -53,7 +53,7 @@
       <div class="ps-nmobile ps-w-100p ps-h-100p ps-noborder ps-nooutline">
         <div class="collection page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}">
           {% assign articles = section.blocks | where: 'type', 'image' %}
-          <sleepink-slider class="slider-mobile-gutter">
+          <sleepink-slider class="slider-mobile-gutter" id="pressslider-desktop">
             <ul class="grid slider slider--desktop slider--tablet grid--peek negative-margin negative-margin--small" role="list">
               {%- for article in articles -%}
                 <li class="slider__slide w-100p">
@@ -93,6 +93,100 @@
       {% comment %} End of Tablet and Desktop Slider {% endcomment %}
     </div>
   </div>
+</div>
+
+<div class="ps-SectionGrid ps-ofl-hidden ps-pos-rel ps-w-100p ps-bgcol-bg ps-pt-9 ps-pt-md-7 ps-pt-lg-10 ps-pb-11 ps-pb-md-12 ps-pb-lg-10 color-{{ section.settings.color_scheme }}">
+  <div class="ps-SectionGrid-Narrow ps-bgcol-bg">
+    <h3 class="ps-ff-heading ps-col-fg ps-fs-7 ps-fs-lg-38px ps-lh-30px ps-lh-lg-44px ps-ls-m124 ps-fw-500 ps-fw-lg-400 ps-mx-auto ps-mb-8 ps-pt-0 ps-ta-c ps-w-84p ps-w-md-74p ps-w-lg-auto">{{ section.settings.title }}</h3>
+    <div>
+      {% comment %} Mobile Slider {% endcomment %}
+      {% comment %} <div class="ps-w-100p ps-h-100p ps-noborder ps-nooutline ps-mobile">
+        <div class="collection page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}">
+          {% assign articles = section.blocks | where: 'type', 'image' %}
+          <sleepink-slider class="slider-mobile-gutter">
+            <ul class="grid slider slider--tablet grid--peek negative-margin negative-margin--small" role="list">
+              {%- for article in articles -%}
+                <li class="slider__slide w-100p">
+                  <div class="ps-flex ps-column ps-jc-spb ps-ai-c ps-w-90vw ps-w-md-85p ps-mxh-230px ps-mnh-md-230px ps-px-38px ps-px-md-11 ps-py-8 ps-py-md-13 ps-mx-auto ps-ta-c">
+                    <h4 class="ps-ff-heading ps-fs-0 ps-fs-md-4 ps-fs-lg-2 ps-fw-300 ps-lh-130 ps-lh-lg-140 ps-mb-5 ps-mb-md-15px ps-mb-lg-18px ps-col-fg">
+                      {{ article.settings.text }}
+                    </h4>
+                    <div class="ps-mxh-30px ps-mxw-80p ps-mnw-50p ps-mt-8 ps-mr-0">
+                      <img 
+                        src="{{ article.settings.image | img_url: 'x30' }}" 
+                        alt="{{ article.settings.image.alt }}" 
+                        width="150"
+                        height="30"
+                        class="ps-contain ps-w-100p ps-h-100p"
+                        loading="lazy"
+                      >
+                    </div>
+                  </div>
+                </li>
+              {%- endfor -%}
+            </ul>
+            {%- if articles.size > 1 and section.settings.swipe_on_mobile -%}
+              <div class="slider-buttons no-js-hidden">
+                <div class="slider-counter caption">
+                  <span class="slider-counter--current">1</span>
+                  <span aria-hidden="true"> / </span>
+                  <span class="visually-hidden">{{ 'accessibility.of' | t }}</span>
+                  <span class="slider-counter--total">{{ articles.size }}</span>
+                </div>
+                <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
+                <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
+              </div>
+            {%- endif -%}
+          </sleepink-slider>
+        </div>
+      </div> {% endcomment %}
+      {% comment %} End of Mobile Slider {% endcomment %}
+      {% comment %} Tablet and Desktop Slider {% endcomment %}
+      <div class="ps-nmobile ps-w-100p ps-h-100p ps-noborder ps-nooutline">
+        <div class="collection page-width{% if section.settings.swipe_on_mobile == true %} page-width-desktop{% endif %}">
+          {% assign articles = section.blocks | where: 'type', 'image' %}
+          <sleepink-slider class="slider-mobile-gutter" id="pressslider-desktop">
+            <ul class="grid slider slider--desktop slider--tablet grid--peek negative-margin negative-margin--small" role="list">
+              {%- for article in articles -%}
+                <li class="slider__slide w-100p">
+                  <div class="ps-flex ps-column ps-jc-spb ps-ai-c ps-w-90vw ps-w-md-85p ps-mxh-230px ps-mnh-md-230px ps-px-38px ps-px-md-11 ps-py-8 ps-py-md-13 ps-mx-auto ps-ta-c">
+                    <h4 class="ps-ff-heading ps-fs-0 ps-fs-md-4 ps-fs-lg-2 ps-fw-300 ps-lh-130 ps-lh-lg-140 ps-mb-5 ps-mb-md-15px ps-mb-lg-18px">
+                      {{ article.settings.text }}
+                    </h4>
+                    <div class="ps-mxh-30px ps-mxw-80p ps-mnw-50p ps-mt-8 ps-mr-0">
+                      <img 
+                        src="{{ article.settings.image | img_url: 'x30' }}" 
+                        alt="{{ article.settings.image.alt }}" 
+                        class="ps-contain ps-w-100p ps-h-100p"
+                        width="150"
+                        height="30"
+                        loading="lazy"
+                      >
+                    </div>
+                  </div>
+                </li>
+              {%- endfor -%}
+            </ul>
+            {%- if articles.size > 1 and section.settings.swipe_on_mobile -%}
+              <div class="slider-buttons no-js-hidden">
+                <div class="slider-counter caption">
+                  <span class="slider-counter--current">1</span>
+                  <span aria-hidden="true"> / </span>
+                  <span class="visually-hidden">{{ 'accessibility.of' | t }}</span>
+                  <span class="slider-counter--total">{{ articles.size }}</span>
+                </div>
+                <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'accessibility.previous_slide' | t }}">{% render 'icon-caret' %}</button>
+                <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'accessibility.next_slide' | t }}">{% render 'icon-caret' %}</button>
+              </div>
+            {%- endif -%}
+          </sleepink-slider>
+        </div>
+      </div>
+      {% comment %} End of Tablet and Desktop Slider {% endcomment %}
+    </div>
+  </div>
+  <div id="prevSlide" class="ps-col-1-2 ps-row-1 ps-mxh-230px ps-ofl-hidden">&nbsp;</div>
+  <div id="nextSlide" class="ps-col-4-5 ps-row-1 ps-mxh-230px ps-ofl-hidden">&nbsp;</div>
 </div>
 
 


### PR DESCRIPTION
# Reparatur und Verbesserung des Pressesliders

- Erstellung eines neuen custom elements `<press-slider>`
- Darstellung der vorherigen und nachfolgenden Slide mit kleinerer Schrift (12pt), kleinerem Logo und 60% Opacity aus dem Desktop
- vorherige und nachfolgende Slide werden auf Smartphones und Tablets aus Platzmangel nicht dargestellt
- Buttons so gestylt wie bei uns auf der Seite und auf einer ähnlichen Position
- Slidenummer wird mit `visibility: hidden;` ausgeblendet
- Korrektur der Schriftgrößen und Abstände

## Screenshots

### Desktop

![grafik](https://user-images.githubusercontent.com/42465490/135999284-7fb2e70d-8127-4e4d-bad2-1fa565eefbf1.png)

### Tablet

![grafik](https://user-images.githubusercontent.com/42465490/135999422-64fd91b0-93a9-4007-aa67-1c753fbd2007.png)

### Smartphone

![grafik](https://user-images.githubusercontent.com/42465490/135999533-a266d3a7-75b5-40b3-9752-e3a44f264b52.png)
