### PR TITLE
Feature/presslogos in hero

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -593,6 +593,10 @@ a:hover {
   padding-bottom: 24px;
 }
 
+.pb-30px {
+  padding-bottom: 30px;
+}
+
 .pb-11 {
   padding-bottom: 56px;
 }
@@ -623,6 +627,10 @@ a:hover {
 
 .pt-12 {
   padding-top: 64px;
+}
+
+.pt-510px {
+  padding-top: 510px;
 }
 
 .pt-550px {
@@ -1539,6 +1547,10 @@ button:active {
     padding-left: 16px;
     padding-right: 16px;
   }
+  .px-md-30px {
+    padding-left: 30px;
+    padding-right: 30px;
+  }
   .px-md-11 {
     padding-top: 56px;
     padding-bottom: 56px;
@@ -1623,6 +1635,9 @@ button:active {
   }
   .bdw-md-3px {
     border-width: 3px;
+  }
+  .ta-md-l {
+    text-align: left;
   }
 }
 

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -613,6 +613,10 @@ a:hover {
   padding-top: 64px;
 }
 
+.pt-600px {
+  padding-top: 600px;
+}
+
 .px-0 {
   padding-left: 0;
   padding-right: 0;

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -293,8 +293,16 @@ a:hover {
   flex-basis: 70%;
 }
 
+.grow {
+  flex-grow: 1;
+}
+
 .shrink {
   flex-shrink: 1;
+}
+
+.shrink-0 {
+  flex-shrink: 0;
 }
 
 .flex-1 {
@@ -855,6 +863,10 @@ a:hover {
 
 .h-400px {
   height: 400px;
+}
+
+.h-620px {
+  height: 620px;
 }
 
 .pos-abs {

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -297,6 +297,10 @@ a:hover {
   flex-grow: 1;
 }
 
+.grow-0 {
+  flex-grow: 0;
+}
+
 .shrink {
   flex-shrink: 1;
 }
@@ -621,6 +625,10 @@ a:hover {
   padding-top: 64px;
 }
 
+.pt-550px {
+  padding-top: 550px;
+}
+
 .pt-600px {
   padding-top: 600px;
 }
@@ -827,6 +835,10 @@ a:hover {
 
 .h-18px {
   height: 18px;
+}
+
+.h-20px {
+  height: 20px;
 }
 
 .h-22px {

--- a/sections/page-hero.liquid
+++ b/sections/page-hero.liquid
@@ -52,7 +52,7 @@
       {% endif %}
       <div class="w-100p col-1 row-1 pt-550px">
         <p class="w-100p ta-c uppercase mb-7">
-          sleep.ink ist bekannt aus:
+          {{ section.settings.introText | escape }}
         </p>
         <div class="flex row jc-spb ai-fs wrap h-20px ofh">
           {% for logo in section.blocks %}
@@ -128,7 +128,7 @@
       </div>
         {% if section.blocks.size > 0 %}
           <div class="col-2-4 row-1 uppercase pt-600px h-620px ofh flex row jc-spb ai-fs wrap w-100p">
-            <p class="uppercase mr-4">Sleep.ink ist bekannt aus:</p>
+            <p class="uppercase mr-4">{{ section.settings.introText | escape }}</p>
             {% for logo in section.blocks %}
               {% if logo.settings.showDesktop %}
                 <img src="{{ logo.settings.image | img_url: 'x50' }}" alt="{{ logo.settings.image.alt | escape }}" width="100" height="20" class="h-20px w-auto mx-5 grow-0 shrink-0" loading="lazy">
@@ -239,6 +239,12 @@
       "id": "buttonText",
       "default": "Jetzt einkaufen",
       "label": "Aufschrift des Buttons"
+    },
+    {
+      "type": "text",
+      "id": "introText",
+      "default": "sleep.ink ist bekannt aus:",
+      "label": "einleitender Text für Presselogos"
     }
   ],
   "blocks": [
@@ -276,7 +282,8 @@
         "text": "Ihre Experten für Premium-Schlafprodukte",
         "url": "/collections/all",
         "buttonDesign": "outlined",
-        "buttonText": "Mehr erfahren"
+        "buttonText": "Mehr erfahren",
+        "introText": "sleep.ink ist bekannt aus:"
       }
     }
   ]

--- a/sections/page-hero.liquid
+++ b/sections/page-hero.liquid
@@ -112,6 +112,16 @@
           </div>
         </div>
       </div>
+        {% if section.blocks.size > 0 %}
+          <div class="col-2-4 row-1 uppercase pt-600px mxh-700px ofh flex row jc-spb ai-c wrap w-100p">
+            <p>Sleep.ink ist bekannt aus:</p>
+            {% for logo in section.blocks %}
+              {% if logo.settings.showDesktop %}
+                <img src="{{ logo.settings.image | img_url: 'x50' }}" alt="{{ logo.settings.image.alt | escape }}" width="100" height="20" class="h-20px w-auto" loading="lazy">
+              {% endif %}
+            {% endfor %}
+          </div>
+        {% endif %}
     </div>
   </div>
 </div>

--- a/sections/page-hero.liquid
+++ b/sections/page-hero.liquid
@@ -217,6 +217,31 @@
       "label": "Aufschrift des Buttons"
     }
   ],
+  "blocks": [
+    {
+      "name": "Presselogo",
+      "type": "image",
+      "settings": [
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "Image"
+        },
+        {
+          "type": "checkbox",
+          "id": "showDesktop",
+          "label": "show on desktop",
+          "default": true
+        },
+        {
+          "type": "checkbox",
+          "id": "showMobile",
+          "label": "show on mobile devices",
+          "default": true
+        }
+      ]
+    }
+  ],
   "presets": [
     {
       "name": "Page Hero",

--- a/sections/page-hero.liquid
+++ b/sections/page-hero.liquid
@@ -34,6 +34,7 @@
 <div class="SectionGrid color-{{ section.settings.color_scheme }}">
   <div class="SectionGrid-Full">
     <div class="ndesktop w-100p">
+      <div class="ngrid onecol onerow">
       {% if section.settings.video != blank and section.settings.video != "" %}
         <video
           muted
@@ -41,14 +42,27 @@
           loop
           poster="{{ section.settings.posterImage | img_url: '2000x' }}"
           src="{{ section.settings.video | escape }}"
-          class="w-100p cover lazy"
+          class="w-100p cover lazy col-1 row-1"
           height="700"
         >
           Sorry, your browser doesn't support embedded videos!
         </video>
         {% else %}
-        <img src="{{ section.settings.imageMobile | img_url: '1200x' }}" alt="{{ section.settings.image.alt | escape }}" class="w-100p cover" width="1000" height="700" loading="lazy">
+        <img src="{{ section.settings.imageMobile | img_url: '1200x' }}" alt="{{ section.settings.image.alt | escape }}" class="w-100p cover col-1 row-1" width="1000" height="700" loading="lazy">
       {% endif %}
+      <div class="w-100p col-1 row-1 pt-550px">
+        <p class="w-100p ta-c uppercase mb-7">
+          sleep.ink ist bekannt aus:
+        </p>
+        <div class="flex row jc-spb ai-fs wrap h-20px ofh">
+          {% for logo in section.blocks %}
+            {% if logo.settings.showMobile %}
+              <img src="{{ logo.settings.image | img_url: 'x50' }}" alt="{{ logo.settings.image.alt | escape }}" loading="lazy" width="100" height="20" class="h-20px w-auto mx-5 grow-0 shrink-0">
+            {% endif %}
+          {% endfor %}
+        </div>
+      </div>
+    </div>
       <div class="w-100p flex column jc-fe">
         <h1 class="ta-c {% if section.settings.uppercaseTitle %}uppercase {% endif %}my-0 py-0 lh-117 ls-m220">
           {{ section.settings.title | escape }}
@@ -113,11 +127,11 @@
         </div>
       </div>
         {% if section.blocks.size > 0 %}
-          <div class="col-2-4 row-1 uppercase pt-600px h-620px ofh flex row jc-spb ai-fs wrap w-100p presselogo-container">
+          <div class="col-2-4 row-1 uppercase pt-600px h-620px ofh flex row jc-spb ai-fs wrap w-100p">
             <p class="uppercase mr-4">Sleep.ink ist bekannt aus:</p>
             {% for logo in section.blocks %}
               {% if logo.settings.showDesktop %}
-                <img src="{{ logo.settings.image | img_url: 'x50' }}" alt="{{ logo.settings.image.alt | escape }}" width="100" height="20" class="h-20px w-auto mx-3 grow shrink-0" loading="lazy">
+                <img src="{{ logo.settings.image | img_url: 'x50' }}" alt="{{ logo.settings.image.alt | escape }}" width="100" height="20" class="h-20px w-auto mx-5 grow-0 shrink-0" loading="lazy">
               {% endif %}
             {% endfor %}
           </div>

--- a/sections/page-hero.liquid
+++ b/sections/page-hero.liquid
@@ -50,27 +50,14 @@
         {% else %}
         <img src="{{ section.settings.imageMobile | img_url: '1200x' }}" alt="{{ section.settings.image.alt | escape }}" class="w-100p cover col-1 row-1" width="1000" height="700" loading="lazy">
       {% endif %}
-      <div class="w-100p col-1 row-1 pt-550px">
-        <p class="w-100p ta-c uppercase mb-7">
-          {{ section.settings.introText | escape }}
-        </p>
-        <div class="flex row jc-spb ai-fs wrap h-20px ofh">
-          {% for logo in section.blocks %}
-            {% if logo.settings.showMobile %}
-              <img src="{{ logo.settings.image | img_url: 'x50' }}" alt="{{ logo.settings.image.alt | escape }}" loading="lazy" width="100" height="20" class="h-20px w-auto mx-5 grow-0 shrink-0">
-            {% endif %}
-          {% endfor %}
-        </div>
-      </div>
-    </div>
-      <div class="w-100p flex column jc-fe">
-        <h1 class="ta-c {% if section.settings.uppercaseTitle %}uppercase {% endif %}my-0 py-0 lh-117 ls-m220">
+      <div class="w-100p col-1 row-1 pt-510px pb-30px px-md-30px">
+        <h1 class="ta-c ta-md-l {% if section.settings.uppercaseTitle %}uppercase {% endif %}my-0 py-0 lh-117 ls-m220">
           {{ section.settings.title | escape }}
         </h1>
-        <p class="ff-body fs-3 lh-133 mt-3 mb-5 ta-c">
+        <p class="ff-body fs-3 lh-133 mt-3 mb-5 ta-c ta-md-l">
           {{ section.settings.text | escape }}
         </p>
-        <div class="ta-c w-100p mt-4 mb-8">
+        <div class="ta-c ta-md-l w-100p mt-4 mb-8">
           {% if section.settings.buttonDesign == "filled" %}
             <a href="{{ section.settings.url }}" class="py-3 px-8 mxh-60px inlblock ta-c ff-heading uppercase z-1000 nodec button" style="background-color: {{ tagBackground }}; color: {{ tagForeground }};">
               {{ section.settings.buttonText | escape }}
@@ -80,6 +67,19 @@
               {{ section.settings.buttonText | escape }}
             </a>
           {% endif %}
+        </div>
+      </div>
+    </div>
+      <div class="w-100p flex column jc-fe">
+        <p class="w-100p ta-c uppercase mb-7">
+          {{ section.settings.introText | escape }}
+        </p>
+        <div class="flex row jc-spb ai-fs wrap h-20px ofh">
+          {% for logo in section.blocks %}
+            {% if logo.settings.showMobile %}
+              <img src="{{ logo.settings.image | img_url: 'x50' }}" alt="{{ logo.settings.image.alt | escape }}" loading="lazy" width="100" height="20" class="h-20px w-auto mx-5 grow-0 shrink-0">
+            {% endif %}
+          {% endfor %}
         </div>
       </div>
     </div>

--- a/sections/page-hero.liquid
+++ b/sections/page-hero.liquid
@@ -113,11 +113,11 @@
         </div>
       </div>
         {% if section.blocks.size > 0 %}
-          <div class="col-2-4 row-1 uppercase pt-600px mxh-700px ofh flex row jc-spb ai-c wrap w-100p">
-            <p>Sleep.ink ist bekannt aus:</p>
+          <div class="col-2-4 row-1 uppercase pt-600px h-620px ofh flex row jc-spb ai-fs wrap w-100p presselogo-container">
+            <p class="uppercase mr-4">Sleep.ink ist bekannt aus:</p>
             {% for logo in section.blocks %}
               {% if logo.settings.showDesktop %}
-                <img src="{{ logo.settings.image | img_url: 'x50' }}" alt="{{ logo.settings.image.alt | escape }}" width="100" height="20" class="h-20px w-auto" loading="lazy">
+                <img src="{{ logo.settings.image | img_url: 'x50' }}" alt="{{ logo.settings.image.alt | escape }}" width="100" height="20" class="h-20px w-auto mx-3 grow shrink-0" loading="lazy">
               {% endif %}
             {% endfor %}
           </div>

--- a/sections/page-hero.liquid
+++ b/sections/page-hero.liquid
@@ -34,19 +34,19 @@
 <div class="SectionGrid color-{{ section.settings.color_scheme }}">
   <div class="SectionGrid-Full">
     <div class="ndesktop w-100p">
-      {% if section.settings.video %}
+      {% if section.settings.video != blank and section.settings.video != "" %}
         <video
           muted
           autoplay
           loop
-          src="{{ section.settings.video | escape }}"
           poster="{{ section.settings.posterImage | img_url: '2000x' }}"
+          src="{{ section.settings.video | escape }}"
           class="w-100p cover lazy"
           height="700"
         >
           Sorry, your browser doesn't support embedded videos!
         </video>
-      {% else %}
+        {% else %}
         <img src="{{ section.settings.imageMobile | img_url: '1200x' }}" alt="{{ section.settings.image.alt | escape }}" class="w-100p cover" width="1000" height="700" loading="lazy">
       {% endif %}
       <div class="w-100p flex column jc-fe">
@@ -70,7 +70,7 @@
       </div>
     </div>
     <div class="w-100p SectionGrid desktopgrid onerow">
-      {% if section.settings.video %}
+      {% if section.settings.video != blank and section.settings.video != "" %}
         <video
           muted
           autoplay


### PR DESCRIPTION
# Implementierung der Presselogos im Hero der Seite

## Features

- Logos werden als Blöcke importiert
- wenn keine Blöcke da sind, werden weder die Logos noch der Einleitungssatz angezeigt
- es werden nur so viele Logos angezeigt, wie in eine Zeile passen

## Screenshots

### Desktop

![grafik](https://user-images.githubusercontent.com/42465490/138235767-5ddd2eac-3086-4524-8e56-ce3ea1bcd05d.png)

### Tablet

![grafik](https://user-images.githubusercontent.com/42465490/138236023-3ac57ac9-bd02-480a-803f-5ae06f96d299.png)

### Mobil

![grafik](https://user-images.githubusercontent.com/42465490/138236274-fe04259d-9cab-47be-933a-c8da7f28a89c.png)

## Logos
Hier habe ich noch eine kleine Auswahl an Presselogos in weiß auf transparentem Hintergrund. Da diese hier in Markdown nicht zu sehen wären, habe ich sie eingerahmt. Der Rahmen ist aber nicht Bestandteil des Bildes.

### ARD
<kbd>
<img src="https://user-images.githubusercontent.com/42465490/138233394-9979a53a-56a1-40a4-a268-c5f121d63fe9.png">
</kbd>

### Bunte
<kbd>
<img src="https://user-images.githubusercontent.com/42465490/138233426-045729c2-0943-405b-bc28-83bf26c05381.png">
</kbd>

### Cosmopolitan
<kbd>
<img src="https://user-images.githubusercontent.com/42465490/138233448-61cd8a55-1d43-42fa-a647-c665380145c7.png">
</kbd>

### Elle
<kbd>
<img src="https://user-images.githubusercontent.com/42465490/138233470-25a4d8ab-4ffd-45a6-be2b-313b85a8426b.png">
</kbd>

### FAZ
<kbd>
<img src="https://user-images.githubusercontent.com/42465490/138233490-b29505f8-efad-4089-8600-34a97a9a4a65.png">
</kbd>

### Freundin
<kbd>
<img src="https://user-images.githubusercontent.com/42465490/138233533-a1cf2443-ab7d-4ee2-9215-c204d4db3952.png">
</kbd>

### Glamour
<kbd>
<img src="https://user-images.githubusercontent.com/42465490/138233547-387247a4-397e-4787-a2b8-cd587723374a.png">
</kbd>

### InStyle
<kbd>
<img src="https://user-images.githubusercontent.com/42465490/138233867-19c3b538-73f5-4c0d-8c1f-15d37d3279d2.png">
</kbd>

### SZ
<kbd>
<img src="https://user-images.githubusercontent.com/42465490/138233576-095c7af1-5cde-44d9-ab0f-d736ff4cb7f1.png">
</kbd>

### Welt
<kbd>
<img src="https://user-images.githubusercontent.com/42465490/138233593-cc22f2c3-448a-4bec-aba4-a21ed9d9bc96.png">
</kbd>

