### PR TITLE
re-add cart notification

### DIFF
--- a/sections/sleepink-header.liquid
+++ b/sections/sleepink-header.liquid
@@ -10,6 +10,7 @@
 
 <script src="{{ 'details-disclosure.js' | asset_url }}" defer="defer"></script>
 <script src="{{ 'details-modal.js' | asset_url }}" defer="defer"></script>
+<script src="{{ 'cart-notification.js' | asset_url }}" defer="defer"></script>
 
 {% liquid 
   case section.settings.color_scheme
@@ -208,6 +209,8 @@
     </div>
   </header>
 </{% if section.settings.enable_sticky_header %}sticky-sleepink-header{% else %}div{% endif %}>
+
+{%- render 'cart-notification', color_scheme: section.settings.color_scheme -%}
 
 <svg xmlns="http://www.w3.org/2000/svg" class="hidden">
   <symbol id="icon-search" viewbox="0 0 18 19" fill="none">


### PR DESCRIPTION
Ich musste lediglich ein Script-Tag und einen Snippet im Header wieder einsetzen, alles andere war noch da. Jetzt erzeugen wir einen anderen Syntax-Error, den ich nicht so ganz nachvollziehen kann. Der Funktionalität tut das aber keinen Abbruch, dafür kommt jetzt so ein Popover herein, was wir noch stylen müssten.