### PR TITLE
Hotfix/redundant stars

### DIFF
--- a/sections/kundenstimmen.liquid
+++ b/sections/kundenstimmen.liquid
@@ -118,37 +118,7 @@
                         </div>
                         {% comment %} Sterne {% endcomment %} 
                         <div class="flex ai-c">
-                          <div class="flex row pos-rel">
-                            {% liquid 
-                              assign missingStars = 5 | minus: recensions[index].settings.rating | floor
-                              assign fullRating = recensions[index].settings.rating | floor
-                              assign sumStars = fullRating | plus: missingStars
-                              if sumStars != 5
-                                assign halfStars = 1
-                              else
-                                assign halfStars = 0
-                              endif
-                            %}
-                            {% if recensions[index].settings.rating > 0 %}
-                              {% for i in (1..fullRating) %}
-                                <span>
-                                  {%- render 'icon-star', currentColor: "#ffd900" -%}
-                                </span>
-                              {% endfor %}
-                            {% endif %}
-                            {% if halfStars == 1 %}
-                              <span>
-                                {%- render 'icon-star-half' -%}
-                              </span>
-                            {% endif %}
-                            {% if missingStars > 0 %}
-                              {% for j in (1..missingStars) %}
-                                <span>
-                                  {%- render 'icon-star', currentColor: "#dddddd" -%}
-                                </span>
-                              {% endfor %}
-                            {% endif %}
-                          </div>
+                          {% render 'star-rating', rating: recensions[index].settings.rating, type: 'review' %}
                         </div>
                         {% comment %} Review text {% endcomment %}
                         <div class="col-fg mt-5 mt-md-4 mt-lg-6 fs-0 lh-186">

--- a/sections/preview-slider.liquid
+++ b/sections/preview-slider.liquid
@@ -54,42 +54,7 @@
                         {% endif %}
                       </h3>
                       <div class="flex js-c ai-c">
-                        {% if product.settings.product.metafields.global.reviewCount and product.settings.product.metafields.global.rating %}
-                          <div>({{ product.settings.product.metafields.global.reviewCount }})</div>
-                          <div class="flex row ml-2 mr-3 ai-c">
-                            {% liquid 
-                              assign rating = product.settings.product.metafields.global.rating
-                              assign wholeRating = rating | floor
-                              assign missing_stars = 5 | minus: rating | floor
-                              assign sum = wholeRating | plus: missing_stars
-                              if sum != 5
-                                assign halfStars = 1
-                              else
-                                assign halfStars = 0
-                              endif
-                            %}
-                            {% if wholeRating > 0 %}
-                              {% for i in (1..wholeRating) %}
-                                <span class="mt-2">
-                                  {%- render 'icon-star', currentColor: '#ffd000' -%}
-                                </span>
-                              {% endfor %}
-                            {% endif %}
-                            {% if halfStars == 1 %}
-                              <span class="mt-2">
-                                {%- render 'icon-star-half' -%}
-                              </span>
-                            {% endif %}
-                            {% for j in (1..missing_stars) %}
-                              <span class="mt-2">
-                                {%- render 'icon-star', currentColor: '#dddddd' -%}
-                              </span>
-                            {% endfor %}
-                          </div>
-                          <a href="https://www.trustedshops.de/bewertung/bewerten_X171CC05C7CF0FBC03EB75B9E6E73D132.html" class="nodec mt-1 ml-1" style="color: {{ tagBackground }};">Jetzt bewerten</a>
-                        {% else %}
-                          &nbsp;
-                        {% endif %}
+                        {%- render 'star-rating', type: 'review', rating: product.settings.product.metafields.global.rating.value, reviewCount: product.settings.product.metafields.global.reviewCount.value -%}
                       </div>
                     </div>
                     <div class="col-1-2 lg-col-2 grid">

--- a/snippets/star-rating.liquid
+++ b/snippets/star-rating.liquid
@@ -133,4 +133,30 @@
         ({% if reviewCount > 0 %}{{ reviewCount }}{% else %}0{% endif %})
       </div>
     </div>
+  {% when 'preview' %}
+    {% if reviewCount and rating %}
+      <div>({{ reviewCount }})</div>
+      <div class="flex row ml-2 mr-3 ai-c">
+        {% if wholeRating > 0 %}
+          {% for i in (1..wholeRating) %}
+            <span class="mt-2">
+              {%- render 'star-yellow-full' -%}
+            </span>
+          {% endfor %}
+        {% endif %}
+        {% if halfStars == 1 %}
+          <span class="mt-2">
+            {%- render 'star-yellow-half' -%}
+          </span>
+        {% endif %}
+        {% for j in (1..missing_stars) %}
+          <span class="mt-2">
+            {%- render 'star-yellow-none' -%}
+          </span>
+        {% endfor %}
+      </div>
+      <a href="https://www.trustedshops.de/bewertung/bewerten_X171CC05C7CF0FBC03EB75B9E6E73D132.html" class="nodec mt-1 ml-1" style="color: {{ tagBackground }};">Jetzt bewerten</a>
+    {% else %}
+      &nbsp;
+    {% endif %}
 {% endcase %}

--- a/snippets/star-rating.liquid
+++ b/snippets/star-rating.liquid
@@ -88,8 +88,8 @@
     </div>
   {% when 'review' %}
     <div class="flex pos-rel">
-      {% if rating > 0 %}
-        {% for i in (1..fullRating) %}
+      {% if wholeRating > 0 %}
+        {% for i in (1..wholeRating) %}
           <span>
             {%- render 'star-yellow-full' -%}
           </span>


### PR DESCRIPTION
# Entfernen der letzten Relikte der alten Stern-Icons

- Abschnitt Kundenstimmen referenziert jetzt die neuen Sterne (`star-rating`)
- Abschnitt Preview-Slider referenziert jetzt die neuen Sterne (`star-rating`)
- Sterne für Kundenstimmen werden auf dem Desktop richtig angezeigt (Bugfix)
- Sterne-Snippet für Preview-Slider erst erzeugt (neuer Abschnitt)